### PR TITLE
CUDA Acceleration for V4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,9 @@ DLL named Immolate. Keep agent work source-faithful, scoped, and validated.
 - Mod metadata/compat: `lovely.toml`, `steamodded_compat.lua`.
 - Rust crate: `Immolate/`; implementation in `Immolate/src/`.
 - Benchmark catalog: `Immolate/src/bench_cases.rs`.
+- CUDA bridge/kernel: `Immolate/src/engine/cuda.rs` and
+  `Immolate/src/cuda/brainstorm_cuda.cu`; Rust CPU remains the correctness
+  oracle and fallback.
 - Rust DLL artifact: `target/rust/Immolate.dll`, staged as `Immolate.dll`.
 - Version source of truth: `[manifest].version` in `lovely.toml`; keep
   `steamodded_compat.lua`, `Immolate/Cargo.toml`, `Immolate/Cargo.lock`, and
@@ -57,6 +60,10 @@ DLL named Immolate. Keep agent work source-faithful, scoped, and validated.
   current and Original DLLs traverse seeds in different orders.
 - UX-fixture report: `mise run bench-ux` measures DLL calls using
   UI-reachable cases and `threads=0`; it is not an in-game Lua profiler.
+- Native-Windows CUDA parity/performance report from WSL:
+  `mise run bench-cuda-long-windows`.
+- Intentional CPU-only experimental build:
+  `BRAINSTORM_SKIP_CUDA_BUILD=1 mise run check`.
 - Native core benchmark:
   `cargo run --manifest-path Immolate/Cargo.toml --release --bin brainstorm_bench -- --case ux --budget 100000 --threads 0 --repeat 5 --warmup 2`.
 
@@ -90,6 +97,14 @@ DLL named Immolate. Keep agent work source-faithful, scoped, and validated.
   face samples after sampling; they are not replaced.
 - Rust search must preserve earliest matching seed semantics for single-thread
   and parallel searches.
+- CUDA is enabled only by the `AR: Use CUDA` setting through
+  `immolate_set_cuda_enabled`. Unsupported filters or an unavailable driver
+  must fall back to Rust CPU without changing result or scanned-count
+  semantics. Initialization and runtime failures latch that process onto CPU;
+  toggling the setting does not retry a failed device.
+- `immolate_last_search_used_cuda` is thread-local and must be queried
+  immediately after a search. It is true only when CUDA handles the remaining
+  search window; CPU prefix hits and every fallback path leave it false.
 
 ## Testing Expectations
 
@@ -104,6 +119,8 @@ DLL named Immolate. Keep agent work source-faithful, scoped, and validated.
   parity audits.
 - For Lua behavior, validate with `mise run lint-lua`; for full confidence run
   `mise run check`.
+- CUDA changes require CPU/GPU result and scanned-count parity, unsupported-path
+  fallback coverage, the CPU-only build, and native-Windows long-window tests.
 
 ## Style
 
@@ -147,6 +164,9 @@ DLL named Immolate. Keep agent work source-faithful, scoped, and validated.
   packaged metadata, and validate the workflow syntax. After publishing, verify
   the GitHub Actions run, **Latest** designation, versioned assets, downloaded
   checksum, and packaged `VERSION` from the remote release.
+- Do not publish a CUDA build until the release workflow provisions pinned
+  `nvcc` and host-compiler versions and intentionally packages its supported GPU
+  architectures. The experimental single-architecture module is branch-only.
 - Do not commit release payloads, generated zips, or staged DLLs. PRs should
   state validation run and whether binary artifacts changed. Attach UI
   screenshots for visual changes.

--- a/Brainstorm.lua
+++ b/Brainstorm.lua
@@ -63,6 +63,7 @@ local DEFAULT_CONFIG = {
   },
   ar_prefs = {
     spf_int = 100000,
+    use_cuda = true,
     face_count = 0,
     suit_ratio_percent = "Disabled",
   },
@@ -259,7 +260,7 @@ function Brainstorm.normalize_config(source)
     merge_string(normalized.ar_filters, filters, "joker_name")
     merge_string(normalized.ar_filters, filters, "joker_search")
     merge_string(normalized.ar_filters, filters, "joker_location")
-    merge_int(normalized.ar_filters, filters, "soul_skip", 0, 5)
+    merge_int(normalized.ar_filters, filters, "soul_skip", 0, 1)
     merge_bool(normalized.ar_filters, filters, "inst_observatory")
     merge_bool(normalized.ar_filters, filters, "inst_perkeo")
     if
@@ -273,6 +274,7 @@ function Brainstorm.normalize_config(source)
   local prefs = source.ar_prefs
   if type(prefs) == "table" then
     merge_int(normalized.ar_prefs, prefs, "spf_int", 1)
+    merge_bool(normalized.ar_prefs, prefs, "use_cuda")
     merge_int(normalized.ar_prefs, prefs, "face_count", 0, 35)
     merge_string(normalized.ar_prefs, prefs, "suit_ratio_percent")
   end
@@ -478,21 +480,18 @@ function Brainstorm.save_state_alert(text)
 end
 
 function Brainstorm.save_game_state(slot)
-  if Brainstorm.is_enabled() and is_run_stage() then
-    local save_path = G.SETTINGS.profile
-      .. "/"
-      .. "save_state_"
-      .. slot
-      .. ".jkr"
-    local success = pcall(compress_and_save, save_path, G.ARGS.save_run)
-    if success then
-      Brainstorm.save_state_alert("Saved state to slot [" .. slot .. "]")
-      return true
-    else
-      Brainstorm.save_state_alert("Failed to save state")
-      return false
-    end
+  if not Brainstorm.is_enabled() or not is_run_stage() then
+    return false
   end
+
+  local save_path = G.SETTINGS.profile .. "/save_state_" .. slot .. ".jkr"
+  local success = pcall(compress_and_save, save_path, G.ARGS.save_run)
+  if success then
+    Brainstorm.save_state_alert("Saved state to slot [" .. slot .. "]")
+    return true
+  end
+
+  Brainstorm.save_state_alert("Failed to save state")
   return false
 end
 
@@ -500,7 +499,7 @@ function Brainstorm.load_game_state(slot)
   if not Brainstorm.is_enabled() or not is_run_stage() then
     return false
   end
-  local save_path = G.SETTINGS.profile .. "/" .. "save_state_" .. slot .. ".jkr"
+  local save_path = G.SETTINGS.profile .. "/save_state_" .. slot .. ".jkr"
   local success, saved_game = pcall(get_compressed, save_path)
 
   if success and saved_game then
@@ -511,14 +510,14 @@ function Brainstorm.load_game_state(slot)
       G:start_run({ savetext = G.SAVED_GAME })
       Brainstorm.save_state_alert("Loaded state from slot [" .. slot .. "]")
       return true
-    else
-      Brainstorm.save_state_alert("Corrupted save in slot [" .. slot .. "]")
-      return false
     end
-  else
-    Brainstorm.save_state_alert("No save in slot [" .. slot .. "]")
+
+    Brainstorm.save_state_alert("Corrupted save in slot [" .. slot .. "]")
     return false
   end
+
+  Brainstorm.save_state_alert("No save in slot [" .. slot .. "]")
+  return false
 end
 
 function Brainstorm.reroll()
@@ -655,7 +654,9 @@ local native_handle = nil
 local DLL_NAME = "Immolate.dll"
 
 local function native_exports(handle)
-  return handle.brainstorm_search, handle.free_result
+  return handle.brainstorm_search,
+    handle.free_result,
+    handle.immolate_set_cuda_enabled
 end
 
 local function init_ffi()
@@ -664,6 +665,7 @@ local function init_ffi()
       ffi.cdef,
       [[
       char* brainstorm_search(const char* seed_start, const char* voucher_key, const char* pack_key, const char* tag1_key, const char* tag2_key, const char* joker_name, const char* joker_location, double souls, bool observatory, bool perkeo, const char* deck_key, bool erratic, bool no_faces, int min_face_cards, double suit_ratio, long long num_seeds, int threads);
+      void immolate_set_cuda_enabled(bool enabled);
       void free_result(char* result);
     ]]
     )
@@ -686,8 +688,14 @@ local function load_native()
     return nil
   end
 
-  local exports_success, search_fn, free_fn = pcall(native_exports, handle)
-  if not exports_success or not search_fn or not free_fn then
+  local exports_success, search_fn, free_fn, set_cuda_enabled =
+    pcall(native_exports, handle)
+  if
+    not exports_success
+    or not search_fn
+    or not free_fn
+    or not set_cuda_enabled
+  then
     return nil
   end
 
@@ -695,6 +703,7 @@ local function load_native()
     dll = handle,
     brainstorm_search = search_fn,
     free_result = free_fn,
+    set_cuda_enabled = set_cuda_enabled,
   }
   return native_handle
 end
@@ -731,7 +740,7 @@ function Brainstorm.auto_reroll()
 
   local immolate = load_native()
   if not immolate then
-    return false, "Auto-reroll stopped (Immolate.dll missing)"
+    return false, "Auto-reroll stopped (Immolate.dll missing or incompatible)"
   end
 
   local pack_key = as_string(filters.pack)
@@ -748,6 +757,19 @@ function Brainstorm.auto_reroll()
   local seed_budget = current_seed_budget(prefs)
   if not seed_budget then
     return false, "Auto-reroll stopped (invalid seed budget)"
+  end
+
+  local cuda_enabled = as_bool(prefs.use_cuda)
+  if immolate.cuda_enabled ~= cuda_enabled then
+    local cuda_success, cuda_error =
+      pcall(immolate.set_cuda_enabled, cuda_enabled)
+    if not cuda_success then
+      return false,
+        "Auto-reroll stopped (CUDA setting failed: "
+          .. tostring(cuda_error)
+          .. ")"
+    end
+    immolate.cuda_enabled = cuda_enabled
   end
 
   local call_success, result = pcall(

--- a/Immolate/BENCH.md
+++ b/Immolate/BENCH.md
@@ -13,6 +13,8 @@ historical DLL and reports comparable result mismatches. It skips fixtures the
 older ABI cannot represent. For measured legacy hits, it preserves the raw
 result and computes scanned work using the Original DLL's length-major
 lexicographic seed order, which differs from the current Rust search order.
+The Rust CPU result and scanned count are the correctness oracle for every CUDA
+measurement; any CPU/GPU mismatch is a hard failure.
 
 Use `BENCH_THREADS=0` for user-facing comparisons and UX reports. That is the
 Lua auto-reroll call path, so it measures what players actually experience.
@@ -95,6 +97,12 @@ Run the DLL UX-fixture report:
 mise run bench-ux
 ```
 
+Run long CUDA windows through the native Windows DLL and driver from WSL:
+
+```bash
+mise run bench-cuda-long-windows
+```
+
 Run one profiling group:
 
 ```bash
@@ -119,7 +127,16 @@ then runs `mise run doctor` to check the system dependencies.
 - MinGW-w64 for Windows target linking and DLL inspection.
 - Wine for running the Windows DLL harness.
 - `sha256sum` for benchmark artifact integrity checks.
-- WSL interoperability (`wslpath` and `cmd.exe`) for native-Windows timing.
+- WSL interoperability (`wslpath`, `cmd.exe`, and `powershell.exe`) for
+  native-Windows timing.
+- CUDA Toolkit with `nvcc` for the GPU-enabled build. Set
+  `BRAINSTORM_SKIP_CUDA_BUILD=1` only for an intentional CPU-fallback build.
+  The defaults are `BRAINSTORM_CUDA_ARCH=sm_89` and `CUDAHOSTCXX=gcc-12`;
+  `NVCC` can select a non-default compiler binary. Each build embeds one
+  precompiled GPU architecture, so set `BRAINSTORM_CUDA_ARCH` to the test GPU's
+  `sm_*` architecture. An incompatible module falls back to Rust CPU and
+  therefore fails strict `cuda-long` backend attestation. Initialization and
+  runtime failures remain latched until the harness process restarts.
 
 Wine may print a `wine32 is missing` warning on Linux. That warning is not a
 failure for this project as long as the 64-bit harness continues and exits
@@ -129,11 +146,12 @@ successfully.
 
 The mise tasks read these environment variables:
 
-- `BENCH_CASE=all|baseline|tags|vouchers|packs|jokers|souls|deck|ux|CASE_NAME`
+- `BENCH_CASE=all|cuda-long|baseline|tags|vouchers|packs|jokers|souls|deck|ux|CASE_NAME`
 - `BENCH_BUDGET=1000000`
 - `BENCH_REPEAT=5`
 - `BENCH_WARMUP=1`
 - `BENCH_THREADS=0`
+- `BENCH_CUDA=default|off|both`
 - `BENCH_MIN_RATIO=1.0`
 - `BENCH_FAIL_ON_MISMATCH=0`
 - `BENCH_FORMAT=pretty|tsv`
@@ -167,6 +185,25 @@ in different orders. Set `BENCH_MIN_RATIO=0.0` only when you want a diagnostic
 report without a speed gate.
 `BENCH_MIN_RATIO` must be finite and non-negative.
 
+`BENCH_CUDA=both` alternates paired CPU/CUDA-enabled samples, uses the p50
+latency ratio, and requires exact result and scanned-count parity. Every call's
+reported backend is queried outside the timed region: CPU arms must report CPU,
+`rust-cuda` means the GPU actually ran, and `rust-cuda-not-used` means an
+enabled regular fixture completed without GPU work, including serial-prefix
+hits and CPU fallback. The `cuda-long` fixtures fail
+if any CUDA-enabled probe, warmup, or measured call falls back. `default`
+preserves the DLL's current setting for historical current-ABI measurements;
+`off` explicitly attests the CPU path. Wine is useful for ABI and fallback
+checks, but native Windows is the performance authority for the Windows CUDA
+driver. The harness reads this status through the
+`immolate_last_search_used_cuda` export; it is not inferred from timing.
+The harness reports phase-zero calls that actually use the GPU as CUDA probe
+rows. In a fresh harness process, the first such row includes lazy driver,
+context, and precompiled-module startup; later probes are warm. The paired
+summary describes steady-state search latency.
+CUDA speed ratios are informational; CPU/GPU result, scanned-count, and backend
+attestation are the hard gates.
+
 `BENCH_FAIL_ON_MISMATCH=0` keeps Rust/original result differences report-only,
 which is the default because the Original DLL is a historical performance
 baseline and its ABI/semantics do not cover every current Brainstorm
@@ -186,6 +223,8 @@ includes:
 - informational Rust/original result mismatches where the historical DLL differs
 - scanned percentage, so early-hit fixtures are obvious
 - mean and p95 latency (full distribution metrics remain available in TSV)
+- counterbalanced CPU/CUDA-enabled p50 ratios, actual backend, and CV for both
+  arms
 - `ns/seed`, which is often the clearest hot-path metric
 - coefficient of variation (`cv`) to flag noisy measurements
 - Rust/original speedup ratio
@@ -211,6 +250,8 @@ helper.
 - `ux-*`: UI-reachable combinations derived from the Lua controls, including
   duplicate tags, forced Buffoon packs, no-pack Soul/Joker searches, special
   deck shop rates, Soul+Perkeo searches, and harder Erratic combinations.
+- `cuda-long-*`: supported full-window GPU fixtures intended for native-Windows
+  CPU/CUDA parity and throughput measurements.
 
 No-match/full-budget cases are the most useful for raw throughput. Early-hit
 cases are still valuable because they catch overhead, result handling, and
@@ -236,8 +277,8 @@ skip    ...
 For `compare` rows, the `impl` column carries the row status (`ok`,
 `below-target`, or `informational`). The relation is stored in the `result`
 field as semicolon-delimited details such as `ratio`, `target_ratio`, `strict`,
-`lhs`, `rhs`, `lhs_sps`, `rhs_sps`, `lhs_ms`, `rhs_ms`, `lhs_result`, and
-`rhs_result`.
+`ratio_basis`, `lhs`, `rhs`, `lhs_sps`, `rhs_sps`, `lhs_mean_ms`,
+`rhs_mean_ms`, `lhs_p50_ms`, `rhs_p50_ms`, `lhs_result`, and `rhs_result`.
 
 ## Original Brainstorm Baseline
 
@@ -276,6 +317,7 @@ These are measured policies, not general abstractions. Keep the independent
 | Seed progression | Fuse sequential seed increment and hash update, but keep arbitrary-ID construction normalized and independently tested. | Carry, growth, wrap, cache-validity, and earliest-result proofs. |
 | Predicate order | Order independent keyed checks by measured rejection cost; preserve source generation order when state or locks are shared. | Source-oracle windows and held-out controls, not one favorable fixture. |
 | Lua active loop | One synchronous batch per active `Game.update`; status text uses the native ref-backed text node. | In-game frame/cancellation evidence and the tracked lifecycle smoke. |
+| CUDA dispatch | Try CUDA only when the user enables it and the compiled filter is supported; otherwise use the Rust CPU path. | Exact CPU/GPU result and scanned-count parity across long, wraparound, and earliest-hit windows. |
 | Settings pips | Suppress only the unreadable 140-choice Joker and 36-choice face-count pip rows. | A supported native UI alternative or visual regression evidence. |
 
 Avoid repeating already falsified families without new evidence: blanket

--- a/Immolate/build.rs
+++ b/Immolate/build.rs
@@ -1,0 +1,61 @@
+#![allow(clippy::panic)]
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/cuda/brainstorm_cuda.cu");
+    println!("cargo:rerun-if-env-changed=BRAINSTORM_SKIP_CUDA_BUILD");
+    println!("cargo:rerun-if-env-changed=BRAINSTORM_CUDA_ARCH");
+    println!("cargo:rerun-if-env-changed=CUDAHOSTCXX");
+    println!("cargo:rerun-if-env-changed=NVCC");
+
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR is set by cargo"));
+    let module_path = out_dir.join("brainstorm_cuda.cubin");
+
+    if env::var_os("BRAINSTORM_SKIP_CUDA_BUILD").is_some_and(|value| value == "1") {
+        std::fs::write(&module_path, b"").expect("write empty CUDA module");
+        return;
+    }
+
+    let nvcc = env::var("NVCC").unwrap_or_else(|_| "nvcc".to_owned());
+    let ccbin = env::var("CUDAHOSTCXX").unwrap_or_else(|_| "gcc-12".to_owned());
+    let arch = env::var("BRAINSTORM_CUDA_ARCH").unwrap_or_else(|_| "sm_89".to_owned());
+
+    let status = Command::new(&nvcc)
+        .args([
+            "-cubin",
+            "-arch",
+            &arch,
+            "-O3",
+            "--Werror",
+            "all-warnings",
+            "--std=c++17",
+            "--fmad=false",
+            "-Xptxas",
+            "-fmad=false",
+            "-prec-div=true",
+            "-prec-sqrt=true",
+            "-ccbin",
+            &ccbin,
+            "-o",
+        ])
+        .arg(&module_path)
+        .arg("src/cuda/brainstorm_cuda.cu")
+        .status();
+
+    match status {
+        Ok(status) if status.success() => {},
+        Ok(status) => {
+            panic!(
+                "nvcc failed with status {status}. Install nvidia-cuda-toolkit or set BRAINSTORM_SKIP_CUDA_BUILD=1"
+            );
+        },
+        Err(err) => {
+            panic!(
+                "failed to run {nvcc}: {err}. Install nvidia-cuda-toolkit or set BRAINSTORM_SKIP_CUDA_BUILD=1"
+            );
+        },
+    }
+}

--- a/Immolate/src/bench_cases.rs
+++ b/Immolate/src/bench_cases.rs
@@ -25,16 +25,7 @@ impl BenchGroup {
     }
 
     pub(crate) const fn label(self) -> &'static str {
-        match self {
-            Self::Baseline => "baseline",
-            Self::Tags => "tags",
-            Self::Vouchers => "vouchers",
-            Self::Packs => "packs",
-            Self::Jokers => "jokers",
-            Self::Souls => "souls",
-            Self::Deck => "deck",
-            Self::Ux => "ux",
-        }
+        self.key()
     }
 }
 
@@ -87,18 +78,27 @@ pub(crate) struct BenchCase {
 pub(crate) fn selected_bench_cases(selected: &str) -> Result<Vec<BenchCase>, String> {
     let mut cases = bench_cases();
     if selected == "all" {
+        cases.retain(|case| !is_cuda_long_case(case));
         return Ok(cases);
     }
 
-    cases.retain(|case| case.name == selected || case.group.key() == selected);
+    cases.retain(|case| {
+        case.name == selected
+            || (selected == "cuda-long" && is_cuda_long_case(case))
+            || (!is_cuda_long_case(case) && case.group.key() == selected)
+    });
     if cases.is_empty() {
         Err(format!(
-            "unknown benchmark case or group: {selected}. Use all, {}, or an exact case name.",
+            "unknown benchmark case or group: {selected}. Use all, cuda-long, {}, or an exact case name.",
             bench_group_keys().join(", ")
         ))
     } else {
         Ok(cases)
     }
+}
+
+fn is_cuda_long_case(case: &BenchCase) -> bool {
+    case.name.starts_with("cuda-long-")
 }
 
 pub(crate) fn bench_group_keys() -> Vec<&'static str> {
@@ -1628,5 +1628,89 @@ pub(crate) fn bench_cases() -> Vec<BenchCase> {
             min_face_cards: 0,
             suit_ratio: 0.0,
         },
+        BenchCase {
+            name: "cuda-long-spectral-soul-legacy-tag",
+            group: BenchGroup::Ux,
+            shape: BenchShape::Mixed,
+            note: "CUDA-supported legacy-representable tag+voucher Spectral Soul long scan",
+            seed_start: "OQMKIM11",
+            voucher: "v_telescope",
+            pack: "p_spectral_mega_1",
+            tag1: "tag_charm",
+            tag2: "",
+            joker: "",
+            joker_location: "any",
+            souls: 1.0,
+            observatory: false,
+            perkeo: false,
+            deck: "b_red",
+            erratic: false,
+            no_faces: false,
+            min_face_cards: 0,
+            suit_ratio: 0.0,
+        },
+        BenchCase {
+            name: "cuda-long-spectral-soul-tag",
+            group: BenchGroup::Ux,
+            shape: BenchShape::Mixed,
+            note: "CUDA-supported Red Deck tag plus Spectral Soul scan sized for tens of millions of seeds",
+            seed_start: "PQTP4311",
+            voucher: "",
+            pack: "p_spectral_mega_1",
+            tag1: "tag_charm",
+            tag2: "tag_charm",
+            joker: "",
+            joker_location: "any",
+            souls: 1.0,
+            observatory: false,
+            perkeo: false,
+            deck: "b_red",
+            erratic: false,
+            no_faces: false,
+            min_face_cards: 0,
+            suit_ratio: 0.0,
+        },
+        BenchCase {
+            name: "cuda-long-spectral-soul-voucher-tag",
+            group: BenchGroup::Ux,
+            shape: BenchShape::Miss,
+            note: "CUDA-supported Red Deck tag+voucher plus Spectral Soul full-budget scan",
+            seed_start: "",
+            voucher: "v_telescope",
+            pack: "p_spectral_mega_1",
+            tag1: "tag_charm",
+            tag2: "tag_charm",
+            joker: "",
+            joker_location: "any",
+            souls: 1.0,
+            observatory: false,
+            perkeo: false,
+            deck: "b_red",
+            erratic: false,
+            no_faces: false,
+            min_face_cards: 0,
+            suit_ratio: 0.0,
+        },
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::selected_bench_cases;
+
+    #[test]
+    fn cuda_long_cases_are_explicitly_selected() {
+        for selector in ["all", "ux"] {
+            assert!(
+                selected_bench_cases(selector)
+                    .expect("built-in selector")
+                    .iter()
+                    .all(|case| !case.name.starts_with("cuda-long-")),
+            );
+        }
+
+        let cases = selected_bench_cases("cuda-long").expect("CUDA selector");
+        assert_eq!(cases.len(), 3);
+        assert!(cases.iter().all(|case| case.name.starts_with("cuda-long-")),);
+    }
 }

--- a/Immolate/src/bin/brainstorm_bench.rs
+++ b/Immolate/src/bin/brainstorm_bench.rs
@@ -33,7 +33,7 @@ fn main() {
     let args = parse_args().unwrap_or_else(|message| {
         eprintln!("{message}");
         eprintln!(
-            "usage: brainstorm_bench [--case all|GROUP|NAME] [--budget N] [--threads N] [--repeat N] [--warmup N]"
+            "usage: brainstorm_bench [--case all|cuda-long|GROUP|NAME] [--budget N] [--threads N] [--repeat N] [--warmup N]"
         );
         process::exit(2);
     });

--- a/Immolate/src/bin/immolate_dll_harness.rs
+++ b/Immolate/src/bin/immolate_dll_harness.rs
@@ -7,6 +7,9 @@ fn main() {
 }
 
 #[cfg(any(windows, test))]
+use std::time::Duration;
+
+#[cfg(any(windows, test))]
 const LEGACY_SEED_SPACE: i64 = 2_318_107_019_761;
 
 #[cfg(any(windows, test))]
@@ -100,11 +103,99 @@ fn validate_min_ratio(min_ratio: f64) -> Result<(), &'static str> {
     }
 }
 
+#[cfg(any(windows, test))]
+fn duration_ratio(numerator: Duration, denominator: Duration) -> f64 {
+    if numerator.is_zero() && denominator.is_zero() {
+        1.0
+    } else {
+        numerator.as_secs_f64() / denominator.as_secs_f64()
+    }
+}
+
+#[cfg(any(windows, test))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CudaBenchMode {
+    Default,
+    Off,
+    Both,
+}
+
+#[cfg(any(windows, test))]
+fn parse_cuda_bench_mode(value: &str) -> Result<CudaBenchMode, String> {
+    match value {
+        "default" => Ok(CudaBenchMode::Default),
+        "off" => Ok(CudaBenchMode::Off),
+        "both" => Ok(CudaBenchMode::Both),
+        _ => Err(format!("invalid --cuda: {value}")),
+    }
+}
+
+#[cfg(any(windows, test))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BenchArm {
+    Cpu,
+    Cuda,
+}
+
+#[cfg(any(windows, test))]
+fn paired_order(index: usize) -> [BenchArm; 2] {
+    if index.is_multiple_of(2) {
+        [BenchArm::Cpu, BenchArm::Cuda]
+    } else {
+        [BenchArm::Cuda, BenchArm::Cpu]
+    }
+}
+
+#[cfg(any(windows, test))]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BackendExpectation {
+    Cpu,
+    Cuda,
+    Either,
+}
+
+#[cfg(any(windows, test))]
+fn attest_backend(
+    expectation: BackendExpectation,
+    used_cuda: Option<bool>,
+) -> Result<bool, &'static str> {
+    let used_cuda = used_cuda.ok_or("DLL does not export immolate_last_search_used_cuda")?;
+    match (expectation, used_cuda) {
+        (BackendExpectation::Cpu, true) => Err("CPU arm used CUDA"),
+        (BackendExpectation::Cuda, false) => Err("CUDA arm fell back to CPU"),
+        _ => Ok(used_cuda),
+    }
+}
+
+#[cfg(any(windows, test))]
+fn observe_backend(observed: &mut Option<bool>, used_cuda: bool) -> Result<(), &'static str> {
+    if observed.is_some_and(|previous| previous != used_cuda) {
+        Err("CUDA-enabled arm changed backend")
+    } else {
+        *observed = Some(used_cuda);
+        Ok(())
+    }
+}
+
+#[cfg(any(windows, test))]
+fn cuda_results_match(
+    cpu_result: &str,
+    cpu_scanned: i64,
+    cuda_result: &str,
+    cuda_scanned: i64,
+) -> bool {
+    cpu_result == cuda_result && cpu_scanned == cuda_scanned
+}
+
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::{
-        LEGACY_SEED_SPACE, LegacyProbe, classify_legacy_probe, is_strict_legacy_comparison,
-        legacy_empty_proves_mismatch, legacy_seed_id, legacy_seed_scan_count,
+        BackendExpectation, BenchArm, CudaBenchMode, LEGACY_SEED_SPACE, LegacyProbe,
+        attest_backend, classify_legacy_probe, cuda_results_match, duration_ratio,
+        is_strict_legacy_comparison, legacy_empty_proves_mismatch, legacy_seed_id,
+        legacy_seed_scan_count, observe_backend, paired_order, parse_cuda_bench_mode,
         requires_strict_legacy_fixture, validate_min_ratio,
     };
 
@@ -185,6 +276,61 @@ mod tests {
         assert!(validate_min_ratio(f64::INFINITY).is_err());
         assert!(validate_min_ratio(f64::NEG_INFINITY).is_err());
     }
+
+    #[test]
+    fn zero_duration_ratios_remain_defined() {
+        assert_eq!(duration_ratio(Duration::ZERO, Duration::ZERO), 1.0);
+        assert_eq!(duration_ratio(Duration::ZERO, Duration::from_nanos(1)), 0.0);
+        assert!(duration_ratio(Duration::from_nanos(1), Duration::ZERO).is_infinite());
+    }
+
+    #[test]
+    fn cuda_modes_have_no_unpaired_or_alias_forms() {
+        assert_eq!(parse_cuda_bench_mode("default"), Ok(CudaBenchMode::Default));
+        assert_eq!(parse_cuda_bench_mode("off"), Ok(CudaBenchMode::Off));
+        assert_eq!(parse_cuda_bench_mode("both"), Ok(CudaBenchMode::Both));
+        for rejected in ["on", "cpu", "cuda"] {
+            assert!(parse_cuda_bench_mode(rejected).is_err());
+        }
+    }
+
+    #[test]
+    fn paired_schedule_counterbalances_adjacent_samples() {
+        assert_eq!(paired_order(0), [BenchArm::Cpu, BenchArm::Cuda]);
+        assert_eq!(paired_order(1), [BenchArm::Cuda, BenchArm::Cpu]);
+        assert_eq!(paired_order(2), paired_order(0));
+    }
+
+    #[test]
+    fn backend_attestation_rejects_missing_wrong_and_changing_backends() {
+        assert_eq!(
+            attest_backend(BackendExpectation::Cpu, Some(false)),
+            Ok(false)
+        );
+        assert_eq!(
+            attest_backend(BackendExpectation::Cuda, Some(true)),
+            Ok(true)
+        );
+        assert_eq!(
+            attest_backend(BackendExpectation::Either, Some(false)),
+            Ok(false)
+        );
+        assert!(attest_backend(BackendExpectation::Cpu, Some(true)).is_err());
+        assert!(attest_backend(BackendExpectation::Cuda, Some(false)).is_err());
+        assert!(attest_backend(BackendExpectation::Either, None).is_err());
+
+        let mut observed = None;
+        assert_eq!(observe_backend(&mut observed, true), Ok(()));
+        assert_eq!(observe_backend(&mut observed, true), Ok(()));
+        assert!(observe_backend(&mut observed, false).is_err());
+    }
+
+    #[test]
+    fn cuda_parity_covers_result_and_scanned_count() {
+        assert!(cuda_results_match("ABC", 42, "ABC", 42));
+        assert!(!cuda_results_match("ABC", 42, "DEF", 42));
+        assert!(!cuda_results_match("ABC", 42, "ABC", 43));
+    }
 }
 
 #[cfg(windows)]
@@ -211,9 +357,10 @@ mod windows_harness {
 
     use super::bench_cases::{self as bench, BenchCase, BenchGroup, BenchShape};
     use super::{
-        LegacyProbe, classify_legacy_probe, is_strict_legacy_comparison,
-        legacy_empty_proves_mismatch, legacy_seed_scan_count, requires_strict_legacy_fixture,
-        validate_min_ratio,
+        BackendExpectation, BenchArm, CudaBenchMode, LegacyProbe, attest_backend,
+        classify_legacy_probe, cuda_results_match, duration_ratio, is_strict_legacy_comparison,
+        legacy_empty_proves_mismatch, legacy_seed_scan_count, observe_backend, paired_order,
+        parse_cuda_bench_mode, requires_strict_legacy_fixture, validate_min_ratio,
     };
 
     type HModule = *mut c_void;
@@ -247,6 +394,8 @@ mod windows_harness {
         bool,
     ) -> *const c_char;
     type FreeResult = unsafe extern "C" fn(*mut c_char);
+    type SetCudaEnabled = unsafe extern "C" fn(bool);
+    type LastSearchUsedCuda = unsafe extern "C" fn() -> bool;
 
     #[link(name = "kernel32")]
     unsafe extern "system" {
@@ -313,11 +462,14 @@ mod windows_harness {
         handle: HModule,
         entry: DllEntry,
         free_result: FreeResult,
+        set_cuda_enabled: Option<SetCudaEnabled>,
+        last_search_used_cuda: Option<LastSearchUsedCuda>,
     }
 
     struct DllRun {
         result: Option<String>,
         elapsed: Duration,
+        used_cuda: Option<bool>,
     }
 
     enum DllEntry {
@@ -338,10 +490,11 @@ mod windows_harness {
                 return Err(format!("failed to load DLL: {path}"));
             }
 
-            let search_name = CString::new("brainstorm_search").map_err(|err| format!("{err}"))?;
-            let free_name = CString::new("free_result").map_err(|err| format!("{err}"))?;
-            let search_ptr = unsafe { GetProcAddress(handle, search_name.as_ptr()) };
-            let free_ptr = unsafe { GetProcAddress(handle, free_name.as_ptr()) };
+            let search_ptr = unsafe { GetProcAddress(handle, c"brainstorm_search".as_ptr()) };
+            let free_ptr = unsafe { GetProcAddress(handle, c"free_result".as_ptr()) };
+            let cuda_ptr = unsafe { GetProcAddress(handle, c"immolate_set_cuda_enabled".as_ptr()) };
+            let cuda_status_ptr =
+                unsafe { GetProcAddress(handle, c"immolate_last_search_used_cuda".as_ptr()) };
             if search_ptr.is_null() || free_ptr.is_null() {
                 unsafe {
                     FreeLibrary(handle);
@@ -357,7 +510,22 @@ mod windows_harness {
                     std::mem::transmute::<FarProc, BrainstormSearch>(search_ptr)
                 }),
                 free_result: unsafe { std::mem::transmute::<FarProc, FreeResult>(free_ptr) },
+                set_cuda_enabled: (!cuda_ptr.is_null())
+                    .then(|| unsafe { std::mem::transmute::<FarProc, SetCudaEnabled>(cuda_ptr) }),
+                last_search_used_cuda: (!cuda_status_ptr.is_null()).then(|| unsafe {
+                    std::mem::transmute::<FarProc, LastSearchUsedCuda>(cuda_status_ptr)
+                }),
             })
+        }
+
+        fn set_cuda_enabled(&self, enabled: bool) -> Result<(), String> {
+            let Some(set_cuda_enabled) = self.set_cuda_enabled else {
+                return Err("DLL does not export immolate_set_cuda_enabled".to_owned());
+            };
+            unsafe {
+                set_cuda_enabled(enabled);
+            }
+            Ok(())
         }
 
         fn run(&self, case: &Case) -> Result<DllRun, String> {
@@ -397,10 +565,8 @@ mod windows_harness {
                 return Err(format!("failed to load original DLL: {path}"));
             }
 
-            let search_name = CString::new("brainstorm").map_err(|err| format!("{err}"))?;
-            let free_name = CString::new("free_result").map_err(|err| format!("{err}"))?;
-            let search_ptr = unsafe { GetProcAddress(handle, search_name.as_ptr()) };
-            let free_ptr = unsafe { GetProcAddress(handle, free_name.as_ptr()) };
+            let search_ptr = unsafe { GetProcAddress(handle, c"brainstorm".as_ptr()) };
+            let free_ptr = unsafe { GetProcAddress(handle, c"free_result".as_ptr()) };
             if search_ptr.is_null() || free_ptr.is_null() {
                 unsafe {
                     FreeLibrary(handle);
@@ -416,6 +582,8 @@ mod windows_harness {
                     std::mem::transmute::<FarProc, OriginalBrainstorm>(search_ptr)
                 }),
                 free_result: unsafe { std::mem::transmute::<FarProc, FreeResult>(free_ptr) },
+                set_cuda_enabled: None,
+                last_search_used_cuda: None,
             })
         }
 
@@ -463,7 +631,12 @@ mod windows_harness {
                 Some(out)
             };
             let elapsed = started.elapsed();
-            Ok(DllRun { result, elapsed })
+            let used_cuda = self.last_search_used_cuda.map(|status| unsafe { status() });
+            Ok(DllRun {
+                result,
+                elapsed,
+                used_cuda,
+            })
         }
 
         fn run_original(&self, case: &Case, search: OriginalBrainstorm) -> Result<DllRun, String> {
@@ -497,7 +670,11 @@ mod windows_harness {
                 Some(out)
             };
             let elapsed = started.elapsed();
-            Ok(DllRun { result, elapsed })
+            Ok(DllRun {
+                result,
+                elapsed,
+                used_cuda: None,
+            })
         }
     }
 
@@ -680,6 +857,7 @@ mod windows_harness {
             threads: i32,
             repeat: usize,
             warmup: usize,
+            cuda: CudaBenchMode,
             output: OutputOptions,
         },
         BenchCompare {
@@ -690,6 +868,7 @@ mod windows_harness {
             threads: i32,
             repeat: usize,
             warmup: usize,
+            cuda: CudaBenchMode,
             min_ratio: f64,
             fail_on_mismatch: bool,
             output: OutputOptions,
@@ -705,6 +884,7 @@ mod windows_harness {
                 threads,
                 repeat,
                 warmup,
+                cuda,
                 output,
             }) => {
                 let settings = BenchSettings {
@@ -715,7 +895,7 @@ mod windows_harness {
                     warmup,
                     output,
                 };
-                if let Err(err) = bench(&dll, settings) {
+                if let Err(err) = bench(&dll, settings, cuda) {
                     eprintln!("{err}");
                     std::process::exit(1);
                 }
@@ -728,6 +908,7 @@ mod windows_harness {
                 threads,
                 repeat,
                 warmup,
+                cuda,
                 min_ratio,
                 fail_on_mismatch,
                 output,
@@ -740,9 +921,14 @@ mod windows_harness {
                     warmup,
                     output,
                 };
-                if let Err(err) =
-                    bench_compare(&rust, &original, settings, min_ratio, fail_on_mismatch)
-                {
+                if let Err(err) = bench_compare(
+                    &rust,
+                    &original,
+                    settings,
+                    cuda,
+                    min_ratio,
+                    fail_on_mismatch,
+                ) {
                     eprintln!("{err}");
                     std::process::exit(1);
                 }
@@ -750,14 +936,18 @@ mod windows_harness {
             Err(err) => {
                 eprintln!("{err}");
                 eprintln!(
-                    "usage:\n  immolate_dll_harness bench --dll PATH [--case all|GROUP|NAME] [--budget N] [--threads N] [--repeat N] [--warmup N] [--format pretty|tsv] [--color auto|always|never]\n  immolate_dll_harness bench-compare --rust PATH --original PATH [--case all|GROUP|NAME] [--budget N] [--threads N] [--repeat N] [--warmup N] [--min-ratio N] [--fail-on-mismatch true|false] [--format pretty|tsv] [--color auto|always|never]"
+                    "usage:\n  immolate_dll_harness bench --dll PATH [--case all|cuda-long|GROUP|NAME] [--budget N] [--threads N] [--repeat N] [--warmup N] [--cuda default|off|both] [--format pretty|tsv] [--color auto|always|never]\n  immolate_dll_harness bench-compare --rust PATH --original PATH [--case all|cuda-long|GROUP|NAME] [--budget N] [--threads N] [--repeat N] [--warmup N] [--cuda default|off|both] [--min-ratio N] [--fail-on-mismatch true|false] [--format pretty|tsv] [--color auto|always|never]"
                 );
                 std::process::exit(2);
             },
         }
     }
 
-    fn bench(dll_path: &str, settings: BenchSettings<'_>) -> Result<(), String> {
+    fn bench(
+        dll_path: &str,
+        settings: BenchSettings<'_>,
+        cuda: CudaBenchMode,
+    ) -> Result<(), String> {
         if settings.budget <= 0 {
             return Err("--budget must be positive".to_owned());
         }
@@ -778,16 +968,26 @@ mod windows_harness {
             );
         }
 
-        let mut summaries = Vec::with_capacity(cases.len());
+        let mut summaries = Vec::with_capacity(cases.len() * 2);
         for case in &cases {
-            summaries.push(measure_bench_case(
-                &dll,
-                case,
-                settings.repeat,
-                settings.warmup,
-                "dll",
-                settings.output,
-            )?);
+            match cuda {
+                CudaBenchMode::Default => {
+                    summaries.push(measure_bench_case(&dll, case, settings, "dll", None, None)?);
+                },
+                CudaBenchMode::Off => summaries.push(measure_bench_case(
+                    &dll,
+                    case,
+                    settings,
+                    "rust-cpu",
+                    Some(false),
+                    Some(BackendExpectation::Cpu),
+                )?),
+                CudaBenchMode::Both => {
+                    let (cpu, cuda) = measure_cuda_pair(&dll, case, settings)?;
+                    summaries.push(cpu);
+                    summaries.push(cuda);
+                },
+            }
         }
         if settings.output.format == OutputFormat::Pretty {
             print_single_bench_report(&summaries, settings.output);
@@ -799,6 +999,7 @@ mod windows_harness {
         rust_path: &str,
         original_path: &str,
         settings: BenchSettings<'_>,
+        cuda: CudaBenchMode,
         min_ratio: f64,
         fail_on_mismatch: bool,
     ) -> Result<(), String> {
@@ -826,25 +1027,27 @@ mod windows_harness {
         let mut failed = false;
         let mut comparisons = Vec::with_capacity(cases.len());
         for case in &cases {
-            let rust_probe = rust.run(case)?.result;
-            let rust_probe_scanned = rust.measured_scanned_count(case, rust_probe.as_deref())?;
-            let rust_probe_result = display_result(rust_probe.as_deref()).to_owned();
-            let rust_summary = measure_bench_case(
-                &rust,
-                case,
-                settings.repeat,
-                settings.warmup,
-                "rust",
-                settings.output,
-            )?;
-            if rust_summary.result != rust_probe_result
-                || rust_summary.scanned != rust_probe_scanned
-            {
-                return Err(format!(
-                    "Rust DLL changed result during {}: probe={rust_probe_result}/{rust_probe_scanned}, measured={}/{}",
-                    case.name, rust_summary.result, rust_summary.scanned,
-                ));
-            }
+            let (rust_summary, rust_cuda) = match cuda {
+                CudaBenchMode::Default => (
+                    measure_current_case(&rust, case, settings, "rust", None, None)?,
+                    None,
+                ),
+                CudaBenchMode::Off => (
+                    measure_current_case(
+                        &rust,
+                        case,
+                        settings,
+                        "rust-cpu",
+                        Some(false),
+                        Some(BackendExpectation::Cpu),
+                    )?,
+                    None,
+                ),
+                CudaBenchMode::Both => {
+                    let (cpu, cuda) = measure_cuda_pair(&rust, case, settings)?;
+                    (cpu, Some(cuda))
+                },
+            };
             let (original_summary, original_skip) = if let Some(reason) = original_skip_reason(case)
             {
                 (None, Some(reason))
@@ -870,14 +1073,8 @@ mod windows_harness {
                     LegacyProbe::Hit { scanned } => {
                         let probe_result =
                             probe_result.expect("non-empty legacy probe has a result");
-                        let summary = measure_bench_case(
-                            &original,
-                            case,
-                            settings.repeat,
-                            settings.warmup,
-                            "original",
-                            settings.output,
-                        )?;
+                        let summary =
+                            measure_bench_case(&original, case, settings, "original", None, None)?;
                         if summary.result != probe_result || summary.scanned != scanned {
                             return Err(format!(
                                 "legacy DLL changed result during {}: probe={probe_result}/{scanned}, measured={}/{}",
@@ -890,6 +1087,7 @@ mod windows_harness {
             };
             let comparison = BenchComparison {
                 rust: rust_summary,
+                rust_cuda,
                 original: original_summary,
                 original_skip,
             };
@@ -972,6 +1170,7 @@ mod windows_harness {
 
     struct BenchComparison {
         rust: BenchSummary,
+        rust_cuda: Option<BenchSummary>,
         original: Option<BenchSummary>,
         original_skip: Option<&'static str>,
     }
@@ -981,6 +1180,12 @@ mod windows_harness {
             self.original.as_ref().map(|original| {
                 original.mean_elapsed.as_secs_f64() / self.rust.mean_elapsed.as_secs_f64()
             })
+        }
+
+        fn cuda_vs_cpu_ratio(&self) -> Option<f64> {
+            self.rust_cuda
+                .as_ref()
+                .map(|cuda| duration_ratio(self.rust.p50_elapsed, cuda.p50_elapsed))
         }
 
         fn is_strictly_comparable(&self) -> bool {
@@ -1009,58 +1214,254 @@ mod windows_harness {
         }
     }
 
+    fn ensure_cuda_parity(
+        case_name: &str,
+        cpu: &BenchSummary,
+        cuda: &BenchSummary,
+    ) -> Result<(), String> {
+        if cuda_results_match(&cpu.result, cpu.scanned, &cuda.result, cuda.scanned) {
+            Ok(())
+        } else {
+            Err(format!(
+                "CUDA parity mismatch in {case_name}: cpu={}/{}, cuda={}/{}",
+                cpu.result, cpu.scanned, cuda.result, cuda.scanned,
+            ))
+        }
+    }
+
+    fn measure_current_case(
+        dll: &Dll,
+        case: &Case,
+        settings: BenchSettings<'_>,
+        implementation: &'static str,
+        cuda_enabled: Option<bool>,
+        backend_expectation: Option<BackendExpectation>,
+    ) -> Result<BenchSummary, String> {
+        if let Some(enabled) = cuda_enabled {
+            dll.set_cuda_enabled(enabled)?;
+        }
+        let (probe, _) = run_bench_sample(dll, case, 0, implementation, backend_expectation)?;
+        let summary = measure_bench_case(
+            dll,
+            case,
+            settings,
+            implementation,
+            cuda_enabled,
+            backend_expectation,
+        )?;
+        if summary.result != probe.result || summary.scanned != probe.scanned {
+            return Err(format!(
+                "Rust DLL changed result during {}: probe={}/{}, measured={}/{}",
+                case.name, probe.result, probe.scanned, summary.result, summary.scanned,
+            ));
+        }
+        Ok(summary)
+    }
+
     fn measure_bench_case(
         dll: &Dll,
         case: &Case,
-        repeat: usize,
-        warmup: usize,
+        settings: BenchSettings<'_>,
         implementation: &'static str,
-        output: OutputOptions,
+        cuda_enabled: Option<bool>,
+        backend_expectation: Option<BackendExpectation>,
     ) -> Result<BenchSummary, String> {
-        run_warmups(dll, case, warmup)?;
-        let mut runs: Vec<BenchRun> = Vec::with_capacity(repeat);
-        for run in 1..=repeat {
-            let DllRun { result, elapsed } = dll.run(case)?;
-            if case.compiled_no_match && result.is_some() {
+        if let Some(enabled) = cuda_enabled {
+            dll.set_cuda_enabled(enabled)?;
+        }
+        run_warmups(
+            dll,
+            case,
+            settings.warmup,
+            implementation,
+            backend_expectation,
+        )?;
+        let mut runs: Vec<BenchRun> = Vec::with_capacity(settings.repeat);
+        for run in 1..=settings.repeat {
+            let (bench_run, _) =
+                run_bench_sample(dll, case, run, implementation, backend_expectation)?;
+            if settings.output.format == OutputFormat::Tsv {
+                print_tsv_run(implementation, case, &bench_run);
+            }
+            push_consistent_run(&mut runs, bench_run, case, implementation)?;
+        }
+        summarize_bench_case(case, implementation, &runs, settings.output)
+    }
+
+    fn measure_cuda_pair(
+        dll: &Dll,
+        case: &Case,
+        settings: BenchSettings<'_>,
+    ) -> Result<(BenchSummary, BenchSummary), String> {
+        let cuda_expectation = if case.name.starts_with("cuda-long-") {
+            BackendExpectation::Cuda
+        } else {
+            BackendExpectation::Either
+        };
+        let final_phase = settings
+            .warmup
+            .checked_add(settings.repeat)
+            .ok_or_else(|| "--warmup plus --repeat is too large".to_owned())?;
+        let mut cpu_probe = None;
+        let mut cuda_probe = None;
+        let mut cpu_runs = Vec::with_capacity(settings.repeat);
+        let mut cuda_runs = Vec::with_capacity(settings.repeat);
+        let mut observed_cuda_backend = None;
+
+        for phase in 0..=final_phase {
+            let measured = phase > settings.warmup;
+            let run = phase.saturating_sub(settings.warmup);
+            let order = paired_order(if measured { run - 1 } else { phase });
+            for arm in order {
+                let (enabled, implementation, expectation) = match arm {
+                    BenchArm::Cpu => (false, "rust-cpu", BackendExpectation::Cpu),
+                    BenchArm::Cuda => (true, "rust-cuda-enabled", cuda_expectation),
+                };
+                dll.set_cuda_enabled(enabled)?;
+                let (bench_run, used_cuda) =
+                    run_bench_sample(dll, case, run, implementation, Some(expectation))?;
+
+                if arm == BenchArm::Cuda {
+                    observe_backend(
+                        &mut observed_cuda_backend,
+                        used_cuda.expect("attested backend is known"),
+                    )
+                    .map_err(|err| format!("{}: {err}", case.name))?;
+                    if phase == 0 && used_cuda == Some(true) {
+                        print_cuda_probe(case, &bench_run, settings.output);
+                    }
+                }
+
+                if phase == 0 {
+                    match arm {
+                        BenchArm::Cpu => cpu_probe = Some(bench_run),
+                        BenchArm::Cuda => cuda_probe = Some(bench_run),
+                    }
+                } else if measured {
+                    let implementation = match arm {
+                        BenchArm::Cpu => "rust-cpu",
+                        BenchArm::Cuda if observed_cuda_backend == Some(true) => "rust-cuda",
+                        BenchArm::Cuda => "rust-cuda-not-used",
+                    };
+                    if settings.output.format == OutputFormat::Tsv {
+                        print_tsv_run(implementation, case, &bench_run);
+                    }
+                    match arm {
+                        BenchArm::Cpu => {
+                            push_consistent_run(&mut cpu_runs, bench_run, case, implementation)?;
+                        },
+                        BenchArm::Cuda => {
+                            push_consistent_run(&mut cuda_runs, bench_run, case, implementation)?;
+                        },
+                    }
+                }
+            }
+        }
+
+        let cuda_implementation = if observed_cuda_backend == Some(true) {
+            "rust-cuda"
+        } else {
+            "rust-cuda-not-used"
+        };
+        let cpu = summarize_bench_case(case, "rust-cpu", &cpu_runs, settings.output)?;
+        let cuda = summarize_bench_case(case, cuda_implementation, &cuda_runs, settings.output)?;
+        for (implementation, probe, summary) in [
+            ("rust-cpu", cpu_probe.expect("paired probe"), &cpu),
+            (
+                cuda_implementation,
+                cuda_probe.expect("paired probe"),
+                &cuda,
+            ),
+        ] {
+            if probe.result != summary.result || probe.scanned != summary.scanned {
                 return Err(format!(
-                    "{} compiled to NoMatch but {implementation} returned a seed",
-                    case.name,
+                    "{} changed result during {implementation}: probe={}/{}, measured={}/{}",
+                    case.name, probe.result, probe.scanned, summary.result, summary.scanned,
                 ));
             }
-            let scanned = dll.measured_scanned_count(case, result.as_deref())?;
-            let elapsed_secs = elapsed.as_secs_f64();
-            let seeds_per_sec = if scanned > 0 && elapsed_secs > 0.0 {
-                scanned as f64 / elapsed_secs
-            } else {
-                0.0
-            };
-            let ns_per_seed = if scanned > 0 {
-                elapsed_secs * 1_000_000_000.0 / scanned as f64
-            } else {
-                0.0
-            };
-            let result = display_result(result.as_deref()).to_owned();
-            if let Some(first) = runs.first()
-                && (first.scanned != scanned || first.result != result)
-            {
-                return Err(format!(
-                    "{} changed result during {implementation}: first={}/{}, run {run}={result}/{scanned}",
-                    case.name, first.result, first.scanned,
-                ));
-            }
-            let bench_run = BenchRun {
+        }
+        ensure_cuda_parity(case.name, &cpu, &cuda)?;
+        Ok((cpu, cuda))
+    }
+
+    fn run_bench_sample(
+        dll: &Dll,
+        case: &Case,
+        run: usize,
+        implementation: &str,
+        backend_expectation: Option<BackendExpectation>,
+    ) -> Result<(BenchRun, Option<bool>), String> {
+        let DllRun {
+            result,
+            elapsed,
+            used_cuda,
+        } = dll.run(case)?;
+        let used_cuda = if let Some(expectation) = backend_expectation {
+            Some(
+                attest_backend(expectation, used_cuda)
+                    .map_err(|err| format!("{} {implementation}: {err}", case.name))?,
+            )
+        } else {
+            used_cuda
+        };
+        if case.compiled_no_match && result.is_some() {
+            return Err(format!(
+                "{} compiled to NoMatch but {implementation} returned a seed",
+                case.name,
+            ));
+        }
+        let scanned = dll.measured_scanned_count(case, result.as_deref())?;
+        let elapsed_secs = elapsed.as_secs_f64();
+        let seeds_per_sec = if scanned > 0 && elapsed_secs > 0.0 {
+            scanned as f64 / elapsed_secs
+        } else {
+            0.0
+        };
+        let ns_per_seed = if scanned > 0 {
+            elapsed_secs * 1_000_000_000.0 / scanned as f64
+        } else {
+            0.0
+        };
+        Ok((
+            BenchRun {
                 run,
                 elapsed,
                 scanned,
                 seeds_per_sec,
                 ns_per_seed,
-                result,
-            };
-            if output.format == OutputFormat::Tsv {
-                print_tsv_run(implementation, case, &bench_run);
-            }
-            runs.push(bench_run);
+                result: display_result(result.as_deref()).to_owned(),
+            },
+            used_cuda,
+        ))
+    }
+
+    fn push_consistent_run(
+        runs: &mut Vec<BenchRun>,
+        run: BenchRun,
+        case: &Case,
+        implementation: &str,
+    ) -> Result<(), String> {
+        if let Some(first) = runs.first()
+            && (first.scanned != run.scanned || first.result != run.result)
+        {
+            return Err(format!(
+                "{} changed result during {implementation}: first={}/{}, run {}={}/{}",
+                case.name, first.result, first.scanned, run.run, run.result, run.scanned,
+            ));
         }
+        runs.push(run);
+        Ok(())
+    }
+
+    fn summarize_bench_case(
+        case: &Case,
+        implementation: &'static str,
+        runs: &[BenchRun],
+        output: OutputOptions,
+    ) -> Result<BenchSummary, String> {
+        let Some(first) = runs.first() else {
+            return Err("--repeat must be positive".to_owned());
+        };
         let mut durations: Vec<_> = runs.iter().map(|run| run.elapsed).collect();
         durations.sort_by(compare_duration);
         let mean_elapsed = mean_duration(&durations);
@@ -1075,7 +1476,7 @@ mod windows_harness {
         } else {
             stdev_elapsed.as_secs_f64() / mean_elapsed.as_secs_f64()
         };
-        let scanned = runs[0].scanned;
+        let scanned = first.scanned;
         let scanned_f64 = scanned as f64;
         let seeds_per_sec = if scanned > 0 && !mean_elapsed.is_zero() {
             scanned_f64 / mean_elapsed.as_secs_f64()
@@ -1088,7 +1489,7 @@ mod windows_harness {
             0.0
         };
         let scanned_pct = scanned_f64 / case.num_seeds as f64;
-        let result = runs[0].result.clone();
+        let result = first.result.clone();
         let summary = BenchSummary {
             implementation,
             case_name: case.name,
@@ -1097,7 +1498,7 @@ mod windows_harness {
             note: case.note,
             budget: case.num_seeds,
             threads: case.threads,
-            repeat,
+            repeat: runs.len(),
             mean_elapsed,
             min_elapsed,
             max_elapsed,
@@ -1118,9 +1519,15 @@ mod windows_harness {
         Ok(summary)
     }
 
-    fn run_warmups(dll: &Dll, case: &Case, warmup: usize) -> Result<(), String> {
+    fn run_warmups(
+        dll: &Dll,
+        case: &Case,
+        warmup: usize,
+        implementation: &str,
+        backend_expectation: Option<BackendExpectation>,
+    ) -> Result<(), String> {
         for _ in 0..warmup {
-            dll.run(case)?;
+            run_bench_sample(dll, case, 0, implementation, backend_expectation)?;
         }
         Ok(())
     }
@@ -1137,6 +1544,7 @@ mod windows_harness {
                 let mut threads = 0;
                 let mut repeat = 5;
                 let mut warmup = 1;
+                let mut cuda = CudaBenchMode::Default;
                 let mut output = OutputOptions::default();
                 parse_flags(&args[1..], |flag, value| match flag {
                     "--dll" => {
@@ -1163,6 +1571,10 @@ mod windows_harness {
                         warmup = parse_value(value, "--warmup")?;
                         Ok(())
                     },
+                    "--cuda" => {
+                        cuda = parse_cuda_bench_mode(value)?;
+                        Ok(())
+                    },
                     "--format" => {
                         output.format = parse_output_format(value)?;
                         Ok(())
@@ -1180,6 +1592,7 @@ mod windows_harness {
                     threads,
                     repeat,
                     warmup,
+                    cuda,
                     output,
                 })
             },
@@ -1191,6 +1604,7 @@ mod windows_harness {
                 let mut threads = 0;
                 let mut repeat = 5;
                 let mut warmup = 1;
+                let mut cuda = CudaBenchMode::Both;
                 let mut min_ratio = 1.0;
                 let mut fail_on_mismatch = false;
                 let mut output = OutputOptions::default();
@@ -1223,6 +1637,10 @@ mod windows_harness {
                         warmup = parse_value(value, "--warmup")?;
                         Ok(())
                     },
+                    "--cuda" => {
+                        cuda = parse_cuda_bench_mode(value)?;
+                        Ok(())
+                    },
                     "--min-ratio" => {
                         min_ratio = parse_value(value, "--min-ratio")?;
                         Ok(())
@@ -1249,6 +1667,7 @@ mod windows_harness {
                     threads,
                     repeat,
                     warmup,
+                    cuda,
                     min_ratio,
                     fail_on_mismatch,
                     output,
@@ -1402,7 +1821,7 @@ mod windows_harness {
     }
 
     fn original_pack_name(key: &str) -> Result<&'static str, String> {
-        match normalize_original_pack_key(key).as_str() {
+        match normalize_original_pack_key(key) {
             "" => Ok(""),
             "p_arcana_normal" => Ok("Arcana Pack"),
             "p_arcana_jumbo" => Ok("Jumbo Arcana Pack"),
@@ -1423,14 +1842,14 @@ mod windows_harness {
         }
     }
 
-    fn normalize_original_pack_key(key: &str) -> String {
+    fn normalize_original_pack_key(key: &str) -> &str {
         let Some((prefix, suffix)) = key.rsplit_once('_') else {
-            return key.to_owned();
+            return key;
         };
         if suffix.chars().all(|ch| ch.is_ascii_digit()) {
-            prefix.to_owned()
+            prefix
         } else {
-            key.to_owned()
+            key
         }
     }
 
@@ -1529,7 +1948,8 @@ mod windows_harness {
         let color = output.use_color();
         print_section("Case Summary", color);
         println!(
-            "{:<18} {:<9} {:<6} {:>7} {:>11} {:>9} {:>9} {:>10} {:>7} {:<12}",
+            "{:<17} {:<18} {:<9} {:<6} {:>7} {:>11} {:>9} {:>9} {:>10} {:>7} {:<12}",
+            "impl",
             "case",
             "group",
             "shape",
@@ -1541,7 +1961,7 @@ mod windows_harness {
             "cv",
             "result",
         );
-        println!("{}", paint(color, ANSI_DIM, &"-".repeat(111)));
+        println!("{}", paint(color, ANSI_DIM, &"-".repeat(129)));
         for summary in summaries {
             let cv = format!("{:.1}%", summary.coefficient_variation * 100.0);
             let cv = paint(
@@ -1550,7 +1970,8 @@ mod windows_harness {
                 &format!("{cv:>7}"),
             );
             println!(
-                "{:<18} {:<9} {:<6} {:>7} {:>11} {:>9.3} {:>9.3} {:>10} {} {:<12}",
+                "{:<17} {:<18} {:<9} {:<6} {:>7} {:>11} {:>9.3} {:>9.3} {:>10} {} {:<12}",
+                summary.implementation,
                 summary.case_name,
                 summary.group.label(),
                 summary.shape.label(),
@@ -1658,9 +2079,55 @@ mod windows_harness {
                 );
             }
         }
+        print_cuda_report(comparisons, color);
         print_result_mismatch_report(comparisons, color);
         print_regression_report(comparisons, min_ratio, color);
         print_noise_report(comparisons, color);
+    }
+
+    fn print_cuda_report(comparisons: &[BenchComparison], color: bool) {
+        if !comparisons
+            .iter()
+            .any(|comparison| comparison.rust_cuda.is_some())
+        {
+            return;
+        }
+
+        print_section("CUDA-enabled vs CPU", color);
+        println!(
+            "{:<18} {:<12} {:>7} {:>11} {:>11} {:>11} {:>17} {:>11}",
+            "case", "backend", "scan", "cpu/s", "enabled/s", "p50 ratio", "p50 ms C/E", "cv C/E",
+        );
+        println!("{}", paint(color, ANSI_DIM, &"-".repeat(108)));
+        for comparison in comparisons {
+            let Some(cuda) = comparison.rust_cuda.as_ref() else {
+                continue;
+            };
+            let ratio = comparison
+                .cuda_vs_cpu_ratio()
+                .expect("CUDA comparison has a ratio");
+            println!(
+                "{:<18} {:<12} {:>7} {:>11} {:>11} {:>11} {:>17} {:>11}",
+                comparison.rust.case_name,
+                cuda.implementation
+                    .strip_prefix("rust-")
+                    .unwrap_or(cuda.implementation),
+                format!("{:.1}%", comparison.rust.scanned_pct * 100.0),
+                format_rate(comparison.rust.seeds_per_sec),
+                format_rate(cuda.seeds_per_sec),
+                paint(color, ratio_color(ratio, 1.0), &format!("{ratio:.3}x")),
+                format!(
+                    "{:.3}/{:.3}",
+                    ms(comparison.rust.p50_elapsed),
+                    ms(cuda.p50_elapsed)
+                ),
+                format!(
+                    "{:.1}/{:.1}%",
+                    comparison.rust.coefficient_variation * 100.0,
+                    cuda.coefficient_variation * 100.0,
+                ),
+            );
+        }
     }
 
     fn print_result_mismatch_report(comparisons: &[BenchComparison], color: bool) {
@@ -1750,6 +2217,10 @@ mod windows_harness {
             .filter(|comparison| {
                 comparison.rust.coefficient_variation > 0.05
                     || comparison
+                        .rust_cuda
+                        .as_ref()
+                        .is_some_and(|cuda| cuda.coefficient_variation > 0.05)
+                    || comparison
                         .original
                         .as_ref()
                         .is_some_and(|original| original.coefficient_variation > 0.05)
@@ -1760,20 +2231,43 @@ mod windows_harness {
         }
         print_section("High Variance", color);
         for comparison in noisy {
+            let cuda_cv = comparison.rust_cuda.as_ref().map_or_else(
+                || "n/a".to_owned(),
+                |cuda| format!("{:>5.1}%", cuda.coefficient_variation * 100.0),
+            );
             let original_cv = comparison.original.as_ref().map_or_else(
                 || "n/a".to_owned(),
                 |original| format!("{:>5.1}%", original.coefficient_variation * 100.0),
             );
             println!(
-                "  {:<18} rust cv {:>5.1}%   original cv {}   repeat or raise budget before trusting small deltas",
+                "  {:<18} cpu cv {:>5.1}%   enabled cv {}   original cv {}   repeat or raise budget before trusting small deltas",
                 comparison.rust.case_name,
                 comparison.rust.coefficient_variation * 100.0,
+                cuda_cv,
                 original_cv,
             );
         }
     }
 
     fn print_original_tsv_compare(comparison: &BenchComparison, min_ratio: f64) {
+        if let Some(cuda) = comparison.rust_cuda.as_ref() {
+            let relation = if cuda.implementation == "rust-cuda" {
+                "rust-cuda-vs-rust-cpu"
+            } else {
+                "rust-cuda-not-used-vs-rust-cpu"
+            };
+            print_tsv_ratio(
+                relation,
+                cuda,
+                &comparison.rust,
+                comparison
+                    .cuda_vs_cpu_ratio()
+                    .expect("CUDA comparison has a ratio"),
+                1.0,
+                false,
+                "p50",
+            );
+        }
         let Some(original) = &comparison.original else {
             if let Some(reason) = comparison.original_skip {
                 let fields = [
@@ -1812,6 +2306,7 @@ mod windows_harness {
                 .expect("original comparison has ratio"),
             min_ratio,
             comparison.is_strictly_comparable(),
+            "mean",
         );
     }
 
@@ -1844,6 +2339,18 @@ mod windows_harness {
             run.ns_per_seed,
             run.result,
         );
+    }
+
+    fn print_cuda_probe(case: &Case, run: &BenchRun, output: OutputOptions) {
+        if output.format == OutputFormat::Tsv {
+            print_tsv_run("rust-cuda-probe", case, run);
+        } else {
+            println!(
+                "CUDA probe: case={} elapsed_ms={:.3} (the process's first GPU probe includes lazy CUDA startup)",
+                case.name,
+                ms(run.elapsed),
+            );
+        }
     }
 
     fn print_tsv_summary(summary: &BenchSummary) {
@@ -1879,6 +2386,7 @@ mod windows_harness {
         ratio: f64,
         target_ratio: f64,
         strict: bool,
+        ratio_basis: &str,
     ) {
         let status = if !strict {
             "informational"
@@ -1888,7 +2396,7 @@ mod windows_harness {
             "below-target"
         };
         println!(
-            "compare\t{}\t{}\t{}\t{}\t{}\t{}\t{:.6}\t{}\t{}\t{:.3}\t{:.0}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\tratio={:.3};target_ratio={:.3};strict={};lhs={};rhs={};lhs_sps={:.0};rhs_sps={:.0};lhs_ms={:.3};rhs_ms={:.3};lhs_result={};rhs_result={}",
+            "compare\t{}\t{}\t{}\t{}\t{}\t{}\t{:.6}\t{}\t{}\t{:.3}\t{:.0}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\t{:.3}\tratio={:.3};ratio_basis={};target_ratio={:.3};strict={};lhs={};rhs={};lhs_sps={:.0};rhs_sps={:.0};lhs_mean_ms={:.3};rhs_mean_ms={:.3};lhs_p50_ms={:.3};rhs_p50_ms={:.3};lhs_result={};rhs_result={}",
             status,
             lhs.case_name,
             lhs.group.key(),
@@ -1909,6 +2417,7 @@ mod windows_harness {
             ms(lhs.stdev_elapsed),
             lhs.coefficient_variation * 100.0,
             ratio,
+            ratio_basis,
             target_ratio,
             strict,
             relation.split("-vs-").next().unwrap_or(relation),
@@ -1917,6 +2426,8 @@ mod windows_harness {
             rhs.seeds_per_sec,
             ms(lhs.mean_elapsed),
             ms(rhs.mean_elapsed),
+            ms(lhs.p50_elapsed),
+            ms(rhs.p50_elapsed),
             lhs.result,
             rhs.result,
         );

--- a/Immolate/src/cuda/brainstorm_cuda.cu
+++ b/Immolate/src/cuda/brainstorm_cuda.cu
@@ -1,0 +1,641 @@
+#include <stdint.h>
+
+struct CudaFilterParams {
+    uint32_t tag1;
+    uint32_t tag2;
+    uint32_t voucher;
+    uint32_t pack;
+    uint32_t flags;
+};
+
+static constexpr uint32_t FLAG_TAGS = 1u << 0;
+static constexpr uint32_t FLAG_VOUCHER = 1u << 1;
+static constexpr uint32_t FLAG_PACKS = 1u << 2;
+static constexpr uint32_t FLAG_OBSERVATORY = 1u << 3;
+static constexpr uint32_t FLAG_SOULS = 1u << 4;
+
+static constexpr uint64_t K_MAX_U64 = 0xffffffffffffffffULL;
+static constexpr uint64_t K_DBL_EXPO = 0x7ff0000000000000ULL;
+static constexpr uint64_t K_DBL_MANT = 0x000fffffffffffffULL;
+static constexpr uint64_t K_DBL_MANT_SIZE = 52ULL;
+static constexpr uint64_t K_DBL_EXPO_SIZE = 11ULL;
+static constexpr uint64_t K_DBL_EXPO_BIAS = 1023ULL;
+static constexpr double PI_HASH = 3.141592653589793116;
+
+static __device__ __constant__ uint8_t SEED_CHARS[35] = {
+    '1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','G','H','I',
+    'J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
+};
+
+static __device__ __constant__ uint32_t TAG_POOL[24] = {
+    310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321,
+    322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333,
+};
+
+static __device__ __constant__ uint32_t VOUCHER_POOL[32] = {
+    162, 163, 164, 165, 166, 167, 168, 169,
+    170, 171, 172, 173, 174, 175, 176, 177,
+    178, 179, 180, 181, 182, 183, 184, 185,
+    186, 187, 188, 189, 190, 191, 192, 193,
+};
+
+static __device__ __constant__ uint32_t PACK_ITEMS[16] = {
+    0, 293, 294, 295, 296, 297, 298, 299,
+    300, 301, 302, 303, 304, 305, 306, 307,
+};
+
+static __device__ __constant__ double PACK_WEIGHTS[16] = {
+    22.42, 4.0, 2.0, 0.5, 4.0, 2.0, 0.5, 4.0,
+    2.0,   0.5, 1.2, 0.6, 0.15, 0.6, 0.3, 0.07,
+};
+
+struct SeedState {
+    int16_t seed[8];
+    uint32_t length;
+};
+
+struct LuaRandom {
+    uint64_t state[4];
+};
+
+static __device__ __forceinline__ uint64_t double_to_bits(double x) {
+    return static_cast<uint64_t>(__double_as_longlong(x));
+}
+
+static __device__ __forceinline__ double bits_to_double(uint64_t x) {
+    return __longlong_as_double(static_cast<long long>(x));
+}
+
+static __device__ double fract_bits(double x) {
+    uint64_t x_int = double_to_bits(x);
+    uint64_t expo = (x_int & K_DBL_EXPO) >> K_DBL_MANT_SIZE;
+    if (expo < K_DBL_EXPO_BIAS) {
+        return x;
+    }
+    if (expo == ((1ULL << K_DBL_EXPO_SIZE) - 1ULL)) {
+        return bits_to_double(0x7ff8000000000000ULL);
+    }
+    uint64_t expo_biased = expo - K_DBL_EXPO_BIAS;
+    if (expo_biased >= K_DBL_MANT_SIZE) {
+        return 0.0;
+    }
+    uint64_t mant = x_int & K_DBL_MANT;
+    uint64_t frac_mant = mant & ((1ULL << (K_DBL_MANT_SIZE - expo_biased)) - 1ULL);
+    if (frac_mant == 0ULL) {
+        return 0.0;
+    }
+    uint64_t frac_lzcnt = static_cast<uint64_t>(__clzll(frac_mant)) - (64ULL - K_DBL_MANT_SIZE);
+    uint64_t res_expo = (expo - frac_lzcnt - 1ULL) << K_DBL_MANT_SIZE;
+    uint64_t res_mant = (frac_mant << (frac_lzcnt + 1ULL)) & K_DBL_MANT;
+    return bits_to_double(res_expo | res_mant);
+}
+
+static __device__ double next_down_for_positive_hash(double x) {
+    if (x == 0.0) {
+        return -bits_to_double(1ULL);
+    }
+    uint64_t bits = double_to_bits(x);
+    if (x > 0.0) {
+        return bits_to_double(bits - 1ULL);
+    }
+    return bits_to_double(bits + 1ULL);
+}
+
+static __device__ double round13(double x) {
+    constexpr double INV_PREC = 10000000000000.0;
+    constexpr double TWO_INV_PREC = 8192.0;
+    constexpr double FIVE_INV_PREC = 1220703125.0;
+
+    double normal_case = floor(x * INV_PREC + 0.5) / INV_PREC;
+    double previous_case = floor(next_down_for_positive_hash(x) * INV_PREC + 0.5) / INV_PREC;
+    if (normal_case == previous_case) {
+        return normal_case;
+    }
+    double truncated = fract_bits(x * TWO_INV_PREC) * FIVE_INV_PREC;
+    if (fract_bits(truncated) >= 0.5) {
+        return (floor(x * INV_PREC) + 1.0) / INV_PREC;
+    }
+    return floor(x * INV_PREC) / INV_PREC;
+}
+
+static __device__ __forceinline__ double pseudostep(uint8_t byte, uint32_t pos, double num) {
+    return fract_bits(1.1239285023 / num * static_cast<double>(byte) * PI_HASH +
+                      PI_HASH * static_cast<double>(pos));
+}
+
+template <int INDEX, uint64_t COEFF>
+static __device__ __forceinline__ void seed_digit(uint64_t* id, SeedState* out) {
+    if (*id > 0ULL) {
+        uint64_t digit = (*id - 1ULL) / COEFF;
+        out->length += 1;
+        out->seed[INDEX] = static_cast<int16_t>(digit);
+        *id -= 1ULL + digit * COEFF;
+    } else {
+        out->seed[INDEX] = -1;
+    }
+}
+
+static __device__ __forceinline__ SeedState seed_from_normalized_id(uint64_t id) {
+    SeedState out{};
+    out.length = 0;
+    seed_digit<0, 66231629136ULL>(&id, &out);
+    seed_digit<1, 1892332261ULL>(&id, &out);
+    seed_digit<2, 54066636ULL>(&id, &out);
+    seed_digit<3, 1544761ULL>(&id, &out);
+    seed_digit<4, 44136ULL>(&id, &out);
+    seed_digit<5, 1261ULL>(&id, &out);
+    seed_digit<6, 36ULL>(&id, &out);
+    seed_digit<7, 1ULL>(&id, &out);
+    return out;
+}
+
+static __device__ __forceinline__ uint8_t seed_char(const SeedState& seed, uint32_t index) {
+    int16_t idx = seed.seed[index];
+    if (idx < 0 || idx >= 35) {
+        return '?';
+    }
+    return SEED_CHARS[idx];
+}
+
+static __device__ double seed_pseudohash(const SeedState& seed, uint32_t prefix_len) {
+    if (seed.length == 0) {
+        return 1.0;
+    }
+    double num = 1.0;
+    for (uint32_t j = 0; j < seed.length; ++j) {
+        num = pseudostep(seed_char(seed, j), prefix_len + seed.length - j, num);
+    }
+    return num;
+}
+
+template <uint32_t N>
+static __device__ double pseudohash_from_key(const uint8_t (&key)[N], double num) {
+    for (int i = static_cast<int>(N) - 2; i >= 0; --i) {
+        num = pseudostep(key[i], static_cast<uint32_t>(i + 1), num);
+    }
+    return num;
+}
+
+static __device__ double initial_node_tag1(const SeedState& seed) {
+    static constexpr uint8_t KEY[] = "Tag1";
+    return pseudohash_from_key(KEY, seed_pseudohash(seed, 4));
+}
+
+static __device__ double initial_node_voucher1(const SeedState& seed) {
+    static constexpr uint8_t KEY[] = "Voucher1";
+    return pseudohash_from_key(KEY, seed_pseudohash(seed, 8));
+}
+
+static __device__ uint32_t append_decimal(uint8_t* key, uint32_t len, int value) {
+    int divisor = 1000;
+    bool started = false;
+    while (divisor > 0) {
+        int digit = (value / divisor) % 10;
+        if (digit != 0 || started || divisor == 1) {
+            key[len++] = static_cast<uint8_t>('0' + digit);
+            started = true;
+        }
+        divisor /= 10;
+    }
+    return len;
+}
+
+static __device__ double initial_node_voucher1_resample(const SeedState& seed, int resample) {
+    uint8_t key[32];
+    const uint8_t prefix[] = "Voucher1_resample";
+    uint32_t len = 0;
+    for (uint32_t i = 0; i < sizeof(prefix) - 1; ++i) {
+        key[len++] = prefix[i];
+    }
+    len = append_decimal(key, len, resample);
+
+    double num = seed_pseudohash(seed, len);
+    for (int i = static_cast<int>(len) - 1; i >= 0; --i) {
+        num = pseudostep(key[i], static_cast<uint32_t>(i + 1), num);
+    }
+    return num;
+}
+
+static __device__ double initial_node_shop_pack1(const SeedState& seed) {
+    static constexpr uint8_t KEY[] = "shop_pack1";
+    return pseudohash_from_key(KEY, seed_pseudohash(seed, 10));
+}
+
+static __device__ double initial_node_soul_tarot1(const SeedState& seed) {
+    static constexpr uint8_t KEY[] = "soul_Tarot1";
+    return pseudohash_from_key(KEY, seed_pseudohash(seed, 11));
+}
+
+static __device__ double initial_node_soul_spectral1(const SeedState& seed) {
+    static constexpr uint8_t KEY[] = "soul_Spectral1";
+    return pseudohash_from_key(KEY, seed_pseudohash(seed, 14));
+}
+
+static __device__ double initial_node_tag1_resample(const SeedState& seed, int resample) {
+    uint8_t key[32];
+    const uint8_t prefix[] = "Tag1_resample";
+    uint32_t len = 0;
+    for (uint32_t i = 0; i < sizeof(prefix) - 1; ++i) {
+        key[len++] = prefix[i];
+    }
+    len = append_decimal(key, len, resample);
+
+    double num = seed_pseudohash(seed, len);
+    for (int i = static_cast<int>(len) - 1; i >= 0; --i) {
+        num = pseudostep(key[i], static_cast<uint32_t>(i + 1), num);
+    }
+    return num;
+}
+
+static __device__ void lua_random_init(LuaRandom* rng, double seed) {
+    double d = seed;
+    uint64_t r = 0x11090601ULL;
+    #pragma unroll
+    for (int i = 0; i < 4; ++i) {
+        uint64_t m = 1ULL << (r & 255ULL);
+        r >>= 8;
+        d = d * 3.14159265358979323846264338327950288 + 2.71828182845904523536028747135266250;
+        uint64_t bits = double_to_bits(d);
+        if (bits < m) {
+            bits += m;
+        }
+        rng->state[i] = bits;
+    }
+    #pragma unroll
+    for (int i = 0; i < 10; ++i) {
+        uint64_t result = 0ULL;
+        uint64_t z = rng->state[0];
+        z = (((z << 31) ^ z) >> 45) ^ ((z & (K_MAX_U64 << 1)) << 18);
+        result ^= z;
+        rng->state[0] = z;
+        z = rng->state[1];
+        z = (((z << 19) ^ z) >> 30) ^ ((z & (K_MAX_U64 << 6)) << 28);
+        result ^= z;
+        rng->state[1] = z;
+        z = rng->state[2];
+        z = (((z << 24) ^ z) >> 48) ^ ((z & (K_MAX_U64 << 9)) << 7);
+        result ^= z;
+        rng->state[2] = z;
+        z = rng->state[3];
+        z = (((z << 21) ^ z) >> 39) ^ ((z & (K_MAX_U64 << 17)) << 8);
+        result ^= z;
+        rng->state[3] = z;
+    }
+}
+
+static __device__ uint64_t lua_randint_raw(LuaRandom* rng) {
+    uint64_t result = 0ULL;
+    uint64_t z = rng->state[0];
+    z = (((z << 31) ^ z) >> 45) ^ ((z & (K_MAX_U64 << 1)) << 18);
+    result ^= z;
+    rng->state[0] = z;
+
+    z = rng->state[1];
+    z = (((z << 19) ^ z) >> 30) ^ ((z & (K_MAX_U64 << 6)) << 28);
+    result ^= z;
+    rng->state[1] = z;
+
+    z = rng->state[2];
+    z = (((z << 24) ^ z) >> 48) ^ ((z & (K_MAX_U64 << 9)) << 7);
+    result ^= z;
+    rng->state[2] = z;
+
+    z = rng->state[3];
+    z = (((z << 21) ^ z) >> 39) ^ ((z & (K_MAX_U64 << 17)) << 8);
+    result ^= z;
+    rng->state[3] = z;
+    return result;
+}
+
+static __device__ double lua_random(double seed) {
+    LuaRandom rng;
+    lua_random_init(&rng, seed);
+    uint64_t bits = (lua_randint_raw(&rng) & 4503599627370495ULL) | 4607182418800017408ULL;
+    return bits_to_double(bits) - 1.0;
+}
+
+static __device__ int lua_randint(double seed, int min, int max) {
+    return static_cast<int>(lua_random(seed) * static_cast<double>(max - min + 1)) + min;
+}
+
+static __device__ double advance_node(double* node, double hashed_seed) {
+    *node = round13(fract_bits((*node) * 1.72431234 + 2.134453429141));
+    return ((*node) + hashed_seed) / 2.0;
+}
+
+static __device__ uint32_t randchoice_tag(
+    const SeedState& seed,
+    double hashed_seed,
+    double* tag_node,
+    int previous_resample_max,
+    int* resample_max
+) {
+    double seed_value = advance_node(tag_node, hashed_seed);
+    int idx = lua_randint(seed_value, 0, 23);
+    uint32_t item = TAG_POOL[idx];
+    if (!(item == 312 || item == 319 || item == 321 || item == 322 || item == 323 ||
+          item == 324 || item == 325 || item == 330 || item == 332)) {
+        return item;
+    }
+
+    for (int resample = 2; resample <= 1000; ++resample) {
+        double node = initial_node_tag1_resample(seed, resample);
+        if (resample <= previous_resample_max) {
+            advance_node(&node, hashed_seed);
+        }
+        seed_value = advance_node(&node, hashed_seed);
+        if (resample > *resample_max) {
+            *resample_max = resample;
+        }
+        idx = lua_randint(seed_value, 0, 23);
+        item = TAG_POOL[idx];
+        if (!(item == 312 || item == 319 || item == 321 || item == 322 || item == 323 ||
+              item == 324 || item == 325 || item == 330 || item == 332)) {
+            return item;
+        }
+    }
+    return item;
+}
+
+static __device__ uint32_t next_voucher(const SeedState& seed, double hashed_seed) {
+    double node = initial_node_voucher1(seed);
+    double seed_value = advance_node(&node, hashed_seed);
+    int idx = lua_randint(seed_value, 0, 31);
+    uint32_t item = VOUCHER_POOL[idx];
+    if (item != 0 && (item - 162) % 2 == 0) {
+        return item;
+    }
+
+    for (int resample = 2; resample <= 1000; ++resample) {
+        node = initial_node_voucher1_resample(seed, resample);
+        seed_value = advance_node(&node, hashed_seed);
+        idx = lua_randint(seed_value, 0, 31);
+        item = VOUCHER_POOL[idx];
+        if (item != 0 && (item - 162) % 2 == 0) {
+            return item;
+        }
+    }
+    return item;
+}
+
+static __device__ uint32_t roll_second_pack(const SeedState& seed, double hashed_seed) {
+    double node = initial_node_shop_pack1(seed);
+    double seed_value = advance_node(&node, hashed_seed);
+    double poll = lua_random(seed_value) * PACK_WEIGHTS[0];
+    double weight = 0.0;
+    for (int i = 1; i < 16; ++i) {
+        weight += PACK_WEIGHTS[i];
+        if (weight >= poll) {
+            return PACK_ITEMS[i];
+        }
+    }
+    return PACK_ITEMS[15];
+}
+
+static __device__ bool second_pack_is(const SeedState& seed, double hashed_seed, uint32_t target) {
+    double node = initial_node_shop_pack1(seed);
+    double seed_value = advance_node(&node, hashed_seed);
+    double poll = lua_random(seed_value) * PACK_WEIGHTS[0];
+    switch (target) {
+        case 298: return poll > 12.5 && poll <= 13.0;
+        case 305: return poll > 21.45 && poll <= 22.05;
+        case 306: return poll > 22.05 && poll <= 22.35;
+        case 307: return poll > 22.35 && poll <= 22.42;
+        default: {
+            double weight = 0.0;
+            for (int i = 1; i < 16; ++i) {
+                weight += PACK_WEIGHTS[i];
+                if (weight >= poll) {
+                    return PACK_ITEMS[i] == target;
+                }
+            }
+            return PACK_ITEMS[15] == target;
+        }
+    }
+}
+
+static __device__ int pack_size(uint32_t pack) {
+    switch (pack) {
+        case 293: return 3;
+        case 294:
+        case 295: return 5;
+        case 305: return 2;
+        case 306:
+        case 307: return 4;
+        default: return 0;
+    }
+}
+
+static __device__ bool spectral_pack_contains_soul_size(
+    const SeedState& seed,
+    double hashed_seed,
+    int size
+);
+
+static __device__ bool pack_contains_soul(
+    const SeedState& seed,
+    double hashed_seed,
+    uint32_t pack
+) {
+    int size = pack_size(pack);
+    if (size <= 0) {
+        return false;
+    }
+
+    if (pack >= 293 && pack <= 295) {
+        double node = initial_node_soul_tarot1(seed);
+        for (int i = 0; i < size; ++i) {
+            double seed_value = advance_node(&node, hashed_seed);
+            if (lua_random(seed_value) > 0.997) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    return spectral_pack_contains_soul_size(seed, hashed_seed, size);
+}
+
+static __device__ bool spectral_pack_contains_soul_size(
+    const SeedState& seed,
+    double hashed_seed,
+    int size
+) {
+    double node = initial_node_soul_spectral1(seed);
+    bool black_hole_locked = false;
+    for (int i = 0; i < size; ++i) {
+        uint32_t forced = 0;
+        double seed_value = advance_node(&node, hashed_seed);
+        if (lua_random(seed_value) > 0.997) {
+            forced = 264;
+        }
+        if (!black_hole_locked) {
+            seed_value = advance_node(&node, hashed_seed);
+            if (lua_random(seed_value) > 0.997) {
+                forced = 265;
+            }
+        }
+        if (forced == 264) {
+            return true;
+        }
+        if (forced == 265) {
+            black_hole_locked = true;
+        }
+    }
+    return false;
+}
+
+static __device__ int spectral_pack_size(uint32_t pack) {
+    switch (pack) {
+        case 305: return 2;
+        case 306:
+        case 307: return 4;
+        default: return 0;
+    }
+}
+
+static __device__ bool tags_match_after_rolls(
+    const SeedState& seed,
+    double hashed_seed,
+    uint32_t tag1,
+    uint32_t tag2
+) {
+    if (tag1 == 0 && tag2 == 0) {
+        return true;
+    }
+
+    double tag_node = initial_node_tag1(seed);
+    int first_resample_max = 1;
+    uint32_t small = randchoice_tag(seed, hashed_seed, &tag_node, 1, &first_resample_max);
+    uint32_t required_big = 0;
+
+    if (tag1 == 0 || tag2 == 0) {
+        uint32_t target = tag1 == 0 ? tag2 : tag1;
+        if (small == target) {
+            return true;
+        }
+        required_big = target;
+    } else if (tag1 != tag2) {
+        if (small == tag1) {
+            required_big = tag2;
+        } else if (small == tag2) {
+            required_big = tag1;
+        } else {
+            return false;
+        }
+    } else {
+        if (small != tag1) {
+            return false;
+        }
+        required_big = tag1;
+    }
+
+    int second_resample_max = first_resample_max;
+    return randchoice_tag(seed, hashed_seed, &tag_node, first_resample_max,
+                          &second_resample_max) == required_big;
+}
+
+static __device__ bool passes_filter(int64_t seed_id, const CudaFilterParams& params) {
+    SeedState seed = seed_from_normalized_id(static_cast<uint64_t>(seed_id));
+    double hashed_seed = seed_pseudohash(seed, 0);
+    uint32_t pack = 0;
+
+    if (params.flags & FLAG_OBSERVATORY) {
+        if (!second_pack_is(seed, hashed_seed, 298)) return false;
+        uint32_t first_voucher = next_voucher(seed, hashed_seed);
+        if (first_voucher != 172) return false;
+    } else {
+        if (params.flags & FLAG_PACKS) {
+            if (!second_pack_is(seed, hashed_seed, params.pack)) return false;
+            pack = params.pack;
+        }
+
+        if (params.flags & FLAG_VOUCHER) {
+            uint32_t first_voucher = next_voucher(seed, hashed_seed);
+            if (params.voucher != 0 && first_voucher != params.voucher) {
+                return false;
+            }
+        }
+
+        if (params.flags & FLAG_SOULS) {
+            if (pack == 0) pack = roll_second_pack(seed, hashed_seed);
+            if (!pack_contains_soul(seed, hashed_seed, pack)) return false;
+        }
+    }
+
+    if (params.flags & FLAG_TAGS) {
+        if (!tags_match_after_rolls(seed, hashed_seed, params.tag1, params.tag2)) return false;
+    }
+
+    return true;
+}
+
+static __device__ bool passes_spectral_soul_filter(
+    int64_t seed_id,
+    const CudaFilterParams& params
+) {
+    SeedState seed = seed_from_normalized_id(static_cast<uint64_t>(seed_id));
+    double hashed_seed = seed_pseudohash(seed, 0);
+
+    if (!second_pack_is(seed, hashed_seed, params.pack)) {
+        return false;
+    }
+
+    if (params.flags & FLAG_VOUCHER) {
+        uint32_t first_voucher = next_voucher(seed, hashed_seed);
+        if (params.voucher != 0 && first_voucher != params.voucher) {
+            return false;
+        }
+    }
+
+    int size = spectral_pack_size(params.pack);
+    if (size <= 0 || !spectral_pack_contains_soul_size(seed, hashed_seed, size)) {
+        return false;
+    }
+
+    if (params.flags & FLAG_TAGS) {
+        if (!tags_match_after_rolls(seed, hashed_seed, params.tag1, params.tag2)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+extern "C" __global__ void brainstorm_search_kernel(
+    int64_t start_seed,
+    int64_t count,
+    CudaFilterParams params,
+    uint64_t* best_offset
+) {
+    uint64_t tid = static_cast<uint64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    uint64_t stride = static_cast<uint64_t>(gridDim.x) * blockDim.x;
+    uint64_t n = static_cast<uint64_t>(count);
+
+    for (uint64_t offset = tid; offset < n; offset += stride) {
+        int64_t seed_id = start_seed + static_cast<int64_t>(offset);
+        if (passes_filter(seed_id, params)) {
+            atomicMin(reinterpret_cast<unsigned long long*>(best_offset),
+                      static_cast<unsigned long long>(offset));
+        }
+    }
+}
+
+extern "C" __global__ void brainstorm_search_spectral_soul_kernel(
+    int64_t start_seed,
+    int64_t count,
+    CudaFilterParams params,
+    uint64_t* best_offset
+) {
+    uint64_t tid = static_cast<uint64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    uint64_t stride = static_cast<uint64_t>(gridDim.x) * blockDim.x;
+    uint64_t n = static_cast<uint64_t>(count);
+
+    for (uint64_t offset = tid; offset < n; offset += stride) {
+        int64_t seed_id = start_seed + static_cast<int64_t>(offset);
+        if (passes_spectral_soul_filter(seed_id, params)) {
+            atomicMin(reinterpret_cast<unsigned long long*>(best_offset),
+                      static_cast<unsigned long long>(offset));
+        }
+    }
+}

--- a/Immolate/src/engine/cuda.rs
+++ b/Immolate/src/engine/cuda.rs
@@ -1,0 +1,1496 @@
+#![allow(unsafe_code)]
+
+use std::cell::Cell;
+use std::ffi::{c_char, c_int, c_uint, c_void};
+use std::mem;
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use crate::engine::config::{CompiledFilter, KernelShape};
+use crate::item::Item;
+use crate::seed::{SEED_SPACE, Seed};
+
+macro_rules! extern_cuda_fn {
+    (fn($($arg:ty),* $(,)?) -> $ret:ty) => {
+        unsafe extern "system" fn($($arg),*) -> $ret
+    };
+}
+
+const CUDA_MODULE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/brainstorm_cuda.cubin"));
+const CUDA_SUCCESS: i32 = 0;
+const NO_RESULT: u64 = u64::MAX;
+const PROBE_LAUNCH_SEEDS: i64 = 16_384;
+const PROBE_WINDOW_SEEDS: i64 = 65_536;
+const LAUNCH_SEEDS: i64 = 2_000_000;
+const BLOCK_SIZE: u32 = 256;
+const GRID_SIZE: u32 = 4096;
+
+type CUdevice = c_int;
+type CUcontext = *mut c_void;
+type CUmodule = *mut c_void;
+type CUfunction = *mut c_void;
+type CUstream = *mut c_void;
+type CUdeviceptr = u64;
+type CUresult = c_int;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct CudaFilterParams {
+    tag1: u32,
+    tag2: u32,
+    voucher: u32,
+    pack: u32,
+    flags: u32,
+}
+
+const FLAG_TAGS: u32 = 1 << 0;
+const FLAG_VOUCHER: u32 = 1 << 1;
+const FLAG_PACKS: u32 = 1 << 2;
+const FLAG_OBSERVATORY: u32 = 1 << 3;
+const FLAG_SOULS: u32 = 1 << 4;
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum CudaSearch {
+    Fallback,
+    Complete(Option<String>),
+}
+
+pub(crate) fn set_cuda_enabled(enabled: bool) {
+    CUDA_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+pub(crate) fn reset_last_search_used() {
+    LAST_SEARCH_USED_CUDA.set(false);
+}
+
+pub(crate) fn mark_last_search_used() {
+    LAST_SEARCH_USED_CUDA.set(true);
+}
+
+pub(crate) fn last_search_used() -> bool {
+    LAST_SEARCH_USED_CUDA.get()
+}
+
+pub(crate) fn search_cuda(start_seed: i64, cfg: &CompiledFilter, num_seeds: i64) -> CudaSearch {
+    if !CUDA_ENABLED.load(Ordering::Relaxed) {
+        return CudaSearch::Fallback;
+    }
+    if CUDA_MODULE.is_empty() {
+        return CudaSearch::Fallback;
+    }
+    let Some(params) = compile_cuda_filter(cfg) else {
+        return CudaSearch::Fallback;
+    };
+
+    let state = CUDA_STATE.get_or_init(|| Mutex::new(CudaState::default()));
+    let Ok(mut guard) = state.lock() else {
+        return CudaSearch::Fallback;
+    };
+    if guard.disabled {
+        return CudaSearch::Fallback;
+    }
+    if guard.engine.is_none() {
+        if let Ok(engine) = CudaEngine::new() {
+            guard.engine = Some(engine);
+        } else {
+            guard.disabled = true;
+            return CudaSearch::Fallback;
+        }
+    }
+    let Some(engine) = guard.engine.as_ref() else {
+        return CudaSearch::Fallback;
+    };
+    let result = engine.search(start_seed, &params, num_seeds);
+    result.map_or_else(
+        |_| {
+            guard.engine = None;
+            guard.disabled = true;
+            CudaSearch::Fallback
+        },
+        CudaSearch::Complete,
+    )
+}
+
+fn compile_cuda_filter(cfg: &CompiledFilter) -> Option<CudaFilterParams> {
+    if cfg.raw.deck != Item::Red_Deck
+        || cfg.raw.joker != Item::RETRY
+        || cfg.raw.souls > 1
+        || cfg.raw.perkeo
+        || cfg.raw.erratic
+        || (cfg.raw.souls > 0 && cfg.raw.observatory)
+    {
+        return None;
+    }
+
+    match cfg.shape {
+        KernelShape::TagOnly
+        | KernelShape::VoucherOnly
+        | KernelShape::VoucherSecondPack
+        | KernelShape::PackOnly
+        | KernelShape::Observatory
+        | KernelShape::TagObservatory
+        | KernelShape::Souls
+        | KernelShape::Composite => {},
+        _ => return None,
+    }
+
+    let mut flags = 0;
+    if cfg.raw.tag1 != Item::RETRY || cfg.raw.tag2 != Item::RETRY {
+        flags |= FLAG_TAGS;
+    }
+    if cfg.raw.voucher != Item::RETRY || cfg.raw.observatory {
+        flags |= FLAG_VOUCHER;
+    }
+    if (cfg.raw.pack != Item::RETRY && cfg.raw.pack != Item::Buffoon_Pack) || cfg.raw.observatory {
+        flags |= FLAG_PACKS;
+    }
+    if cfg.raw.observatory {
+        flags |= FLAG_OBSERVATORY;
+    }
+    if cfg.raw.souls > 0 {
+        flags |= FLAG_SOULS;
+    }
+
+    if flags == 0 {
+        return None;
+    }
+
+    Some(CudaFilterParams {
+        tag1: item_id_or_zero(cfg.raw.tag1),
+        tag2: item_id_or_zero(cfg.raw.tag2),
+        voucher: item_id_or_zero(cfg.raw.voucher),
+        pack: item_id_or_zero(cfg.raw.pack),
+        flags,
+    })
+}
+
+fn item_id_or_zero(item: Item) -> u32 {
+    if item == Item::RETRY {
+        0
+    } else {
+        u32::from(item as u16)
+    }
+}
+
+static CUDA_ENABLED: AtomicBool = AtomicBool::new(false);
+static CUDA_STATE: OnceLock<Mutex<CudaState>> = OnceLock::new();
+
+thread_local! {
+    static LAST_SEARCH_USED_CUDA: Cell<bool> = const { Cell::new(false) };
+}
+
+#[derive(Default)]
+struct CudaState {
+    engine: Option<CudaEngine>,
+    disabled: bool,
+}
+
+struct CudaEngine {
+    driver: CudaDriver,
+    context: CUcontext,
+    module: CUmodule,
+    kernel: CUfunction,
+    spectral_soul_kernel: CUfunction,
+    d_best_offset: CUdeviceptr,
+}
+
+// SAFETY: every driver/context access is serialized by `CUDA_STATE`'s mutex.
+unsafe impl Send for CudaEngine {}
+
+impl CudaEngine {
+    fn new() -> Result<Self, CudaError> {
+        let driver = CudaDriver::load()?;
+        let mut engine = Self {
+            driver,
+            context: ptr::null_mut(),
+            module: ptr::null_mut(),
+            kernel: ptr::null_mut(),
+            spectral_soul_kernel: ptr::null_mut(),
+            d_best_offset: 0,
+        };
+        unsafe {
+            check((engine.driver.cu_init)(0))?;
+
+            let mut device_count = 0;
+            check((engine.driver.cu_device_get_count)(&raw mut device_count))?;
+            if device_count <= 0 {
+                return Err(CudaError::NoDevice);
+            }
+
+            let mut device = 0;
+            check((engine.driver.cu_device_get)(&raw mut device, 0))?;
+
+            check((engine.driver.cu_ctx_create)(
+                &raw mut engine.context,
+                0,
+                device,
+            ))?;
+            // SAFETY: `cuCtxCreate` leaves the new context current on this thread.
+            let _current = CurrentContext::assume_current(&engine.driver);
+
+            check((engine.driver.cu_module_load_data_ex)(
+                &raw mut engine.module,
+                CUDA_MODULE.as_ptr().cast(),
+                0,
+                ptr::null_mut(),
+                ptr::null_mut(),
+            ))?;
+
+            let kernel_name = c"brainstorm_search_kernel";
+            check((engine.driver.cu_module_get_function)(
+                &raw mut engine.kernel,
+                engine.module,
+                kernel_name.as_ptr(),
+            ))?;
+            let spectral_soul_kernel_name = c"brainstorm_search_spectral_soul_kernel";
+            check((engine.driver.cu_module_get_function)(
+                &raw mut engine.spectral_soul_kernel,
+                engine.module,
+                spectral_soul_kernel_name.as_ptr(),
+            ))?;
+
+            check((engine.driver.cu_mem_alloc)(
+                &raw mut engine.d_best_offset,
+                mem::size_of::<u64>(),
+            ))?;
+        }
+        Ok(engine)
+    }
+
+    fn search(
+        &self,
+        start_seed: i64,
+        params: &CudaFilterParams,
+        num_seeds: i64,
+    ) -> Result<Option<String>, CudaError> {
+        let mut remaining = num_seeds.clamp(0, SEED_SPACE);
+        if remaining == 0 {
+            return Ok(None);
+        }
+        let mut start_seed = start_seed.rem_euclid(SEED_SPACE);
+        let _current = CurrentContext::push(&self.driver, self.context)?;
+
+        while remaining > 0 {
+            let until_wrap = SEED_SPACE - start_seed;
+            let mut segment_remaining = remaining.min(until_wrap);
+            let mut next_launch = first_launch_size(segment_remaining);
+            while segment_remaining > 0 {
+                let count = segment_remaining.min(next_launch);
+                let found = self.search_launch(start_seed, count, params)?;
+                if let Some(offset) = found {
+                    let offset = i64::try_from(offset).map_err(|_| CudaError::InvalidOffset)?;
+                    let id = (start_seed + offset).rem_euclid(SEED_SPACE);
+                    return Ok(Some(Seed::from_id(id).to_string()));
+                }
+                remaining -= count;
+                segment_remaining -= count;
+                start_seed = (start_seed + count).rem_euclid(SEED_SPACE);
+                next_launch = LAUNCH_SEEDS;
+            }
+        }
+        Ok(None)
+    }
+
+    fn search_launch(
+        &self,
+        start_seed: i64,
+        count: i64,
+        params: &CudaFilterParams,
+    ) -> Result<Option<u64>, CudaError> {
+        let mut best_offset = NO_RESULT;
+        unsafe {
+            check((self.driver.cu_memcpy_htod)(
+                self.d_best_offset,
+                ptr::from_ref(&best_offset).cast(),
+                mem::size_of::<u64>(),
+            ))?;
+
+            let mut start_seed_arg = start_seed;
+            let mut count_arg = count;
+            let mut params_arg = *params;
+            let mut best_arg = self.d_best_offset;
+            let mut args = [
+                ptr::from_mut(&mut start_seed_arg).cast::<c_void>(),
+                ptr::from_mut(&mut count_arg).cast::<c_void>(),
+                ptr::from_mut(&mut params_arg).cast::<c_void>(),
+                ptr::from_mut(&mut best_arg).cast::<c_void>(),
+            ];
+            let kernel = self.search_kernel(params);
+
+            check((self.driver.cu_launch_kernel)(
+                kernel,
+                launch_grid_size(count),
+                1,
+                1,
+                BLOCK_SIZE,
+                1,
+                1,
+                0,
+                ptr::null_mut(),
+                args.as_mut_ptr(),
+                ptr::null_mut(),
+            ))?;
+            check((self.driver.cu_memcpy_dtoh)(
+                ptr::from_mut(&mut best_offset).cast(),
+                self.d_best_offset,
+                mem::size_of::<u64>(),
+            ))?;
+        }
+
+        match best_offset {
+            NO_RESULT => Ok(None),
+            offset if offset < u64::try_from(count).map_err(|_| CudaError::InvalidOffset)? => {
+                Ok(Some(offset))
+            },
+            _ => Err(CudaError::InvalidOffset),
+        }
+    }
+
+    fn search_kernel(&self, params: &CudaFilterParams) -> CUfunction {
+        if use_spectral_soul_kernel(params) {
+            self.spectral_soul_kernel
+        } else {
+            self.kernel
+        }
+    }
+}
+
+struct CurrentContext<'a> {
+    driver: &'a CudaDriver,
+}
+
+impl<'a> CurrentContext<'a> {
+    unsafe fn assume_current(driver: &'a CudaDriver) -> Self {
+        Self { driver }
+    }
+
+    fn push(driver: &'a CudaDriver, context: CUcontext) -> Result<Self, CudaError> {
+        unsafe {
+            check((driver.cu_ctx_push_current)(context))?;
+        }
+        Ok(Self { driver })
+    }
+}
+
+impl Drop for CurrentContext<'_> {
+    fn drop(&mut self) {
+        let mut popped = ptr::null_mut();
+        unsafe {
+            let _ = (self.driver.cu_ctx_pop_current)(&raw mut popped);
+        }
+    }
+}
+
+fn use_spectral_soul_kernel(params: &CudaFilterParams) -> bool {
+    let allowed_flags = FLAG_TAGS | FLAG_VOUCHER | FLAG_PACKS | FLAG_SOULS;
+    params.flags & !allowed_flags == 0
+        && params.flags & FLAG_PACKS != 0
+        && params.flags & FLAG_SOULS != 0
+        && matches!(params.pack, 305..=307)
+}
+
+fn launch_grid_size(count: i64) -> u32 {
+    let count = u64::try_from(count).unwrap_or(0).max(1);
+    let block_size = u64::from(BLOCK_SIZE);
+    let blocks = count.div_ceil(block_size);
+    u32::try_from(blocks.min(u64::from(GRID_SIZE))).unwrap_or(GRID_SIZE)
+}
+
+fn first_launch_size(segment_seeds: i64) -> i64 {
+    // Avoid queuing a full throughput grid before an early result can stop it.
+    if segment_seeds >= PROBE_WINDOW_SEEDS {
+        PROBE_LAUNCH_SEEDS
+    } else {
+        LAUNCH_SEEDS
+    }
+}
+
+impl Drop for CudaEngine {
+    fn drop(&mut self) {
+        if self.context.is_null() {
+            return;
+        }
+        if let Ok(_current) = CurrentContext::push(&self.driver, self.context) {
+            unsafe {
+                if self.d_best_offset != 0 {
+                    let _ = (self.driver.cu_mem_free)(self.d_best_offset);
+                }
+                if !self.module.is_null() {
+                    let _ = (self.driver.cu_module_unload)(self.module);
+                }
+            }
+        }
+        unsafe {
+            // Destroy the detached context after the guard restores the caller.
+            let _ = (self.driver.cu_ctx_destroy)(self.context);
+        }
+    }
+}
+
+#[derive(Debug)]
+enum CudaError {
+    Load,
+    Symbol,
+    NoDevice,
+    InvalidOffset,
+    Driver,
+}
+
+fn check(result: CUresult) -> Result<(), CudaError> {
+    if result == CUDA_SUCCESS {
+        Ok(())
+    } else {
+        Err(CudaError::Driver)
+    }
+}
+
+struct CudaDriver {
+    _lib: DynamicLibrary,
+    cu_init: extern_cuda_fn!(fn(c_uint) -> CUresult),
+    cu_device_get: extern_cuda_fn!(fn(*mut CUdevice, c_int) -> CUresult),
+    cu_device_get_count: extern_cuda_fn!(fn(*mut c_int) -> CUresult),
+    cu_ctx_create: extern_cuda_fn!(fn(*mut CUcontext, c_uint, CUdevice) -> CUresult),
+    cu_ctx_destroy: extern_cuda_fn!(fn(CUcontext) -> CUresult),
+    #[cfg(test)]
+    cu_ctx_get_current: extern_cuda_fn!(fn(*mut CUcontext) -> CUresult),
+    cu_ctx_push_current: extern_cuda_fn!(fn(CUcontext) -> CUresult),
+    cu_ctx_pop_current: extern_cuda_fn!(fn(*mut CUcontext) -> CUresult),
+    cu_module_load_data_ex: extern_cuda_fn!(
+        fn(*mut CUmodule, *const c_void, c_uint, *mut c_void, *mut c_void) -> CUresult
+    ),
+    cu_module_get_function:
+        extern_cuda_fn!(fn(*mut CUfunction, CUmodule, *const c_char) -> CUresult),
+    cu_module_unload: extern_cuda_fn!(fn(CUmodule) -> CUresult),
+    cu_mem_alloc: extern_cuda_fn!(fn(*mut CUdeviceptr, usize) -> CUresult),
+    cu_mem_free: extern_cuda_fn!(fn(CUdeviceptr) -> CUresult),
+    cu_memcpy_htod: extern_cuda_fn!(fn(CUdeviceptr, *const c_void, usize) -> CUresult),
+    cu_memcpy_dtoh: extern_cuda_fn!(fn(*mut c_void, CUdeviceptr, usize) -> CUresult),
+    cu_launch_kernel: extern_cuda_fn!(
+        fn(
+            CUfunction,
+            c_uint,
+            c_uint,
+            c_uint,
+            c_uint,
+            c_uint,
+            c_uint,
+            c_uint,
+            CUstream,
+            *mut *mut c_void,
+            *mut *mut c_void,
+        ) -> CUresult
+    ),
+}
+
+impl CudaDriver {
+    fn load() -> Result<Self, CudaError> {
+        let lib = DynamicLibrary::open_cuda()?;
+        unsafe {
+            Ok(Self {
+                cu_init: lib.symbol(b"cuInit\0")?,
+                cu_device_get: lib.symbol(b"cuDeviceGet\0")?,
+                cu_device_get_count: lib.symbol(b"cuDeviceGetCount\0")?,
+                cu_ctx_create: lib.symbol_any(&[b"cuCtxCreate_v2\0", b"cuCtxCreate\0"])?,
+                cu_ctx_destroy: lib.symbol_any(&[b"cuCtxDestroy_v2\0", b"cuCtxDestroy\0"])?,
+                #[cfg(test)]
+                cu_ctx_get_current: lib.symbol(b"cuCtxGetCurrent\0")?,
+                cu_ctx_push_current: lib
+                    .symbol_any(&[b"cuCtxPushCurrent_v2\0", b"cuCtxPushCurrent\0"])?,
+                cu_ctx_pop_current: lib
+                    .symbol_any(&[b"cuCtxPopCurrent_v2\0", b"cuCtxPopCurrent\0"])?,
+                cu_module_load_data_ex: lib.symbol(b"cuModuleLoadDataEx\0")?,
+                cu_module_get_function: lib.symbol(b"cuModuleGetFunction\0")?,
+                cu_module_unload: lib.symbol(b"cuModuleUnload\0")?,
+                cu_mem_alloc: lib.symbol_any(&[b"cuMemAlloc_v2\0", b"cuMemAlloc\0"])?,
+                cu_mem_free: lib.symbol_any(&[b"cuMemFree_v2\0", b"cuMemFree\0"])?,
+                cu_memcpy_htod: lib.symbol_any(&[b"cuMemcpyHtoD_v2\0", b"cuMemcpyHtoD\0"])?,
+                cu_memcpy_dtoh: lib.symbol_any(&[b"cuMemcpyDtoH_v2\0", b"cuMemcpyDtoH\0"])?,
+                cu_launch_kernel: lib.symbol(b"cuLaunchKernel\0")?,
+                _lib: lib,
+            })
+        }
+    }
+}
+
+struct DynamicLibrary {
+    handle: *mut c_void,
+}
+
+unsafe impl Send for DynamicLibrary {}
+
+impl DynamicLibrary {
+    fn open_cuda() -> Result<Self, CudaError> {
+        for name in cuda_library_names() {
+            if let Ok(lib) = Self::open(name) {
+                return Ok(lib);
+            }
+        }
+        Err(CudaError::Load)
+    }
+
+    unsafe fn symbol<T: Copy>(&self, name: &[u8]) -> Result<T, CudaError> {
+        let ptr = unsafe { self.raw_symbol(name) };
+        if ptr.is_null() {
+            return Err(CudaError::Symbol);
+        }
+        Ok(unsafe { mem::transmute_copy(&ptr) })
+    }
+
+    unsafe fn symbol_any<T: Copy>(&self, names: &[&[u8]]) -> Result<T, CudaError> {
+        for name in names {
+            if let Ok(symbol) = unsafe { self.symbol(name) } {
+                return Ok(symbol);
+            }
+        }
+        Err(CudaError::Symbol)
+    }
+}
+
+impl Drop for DynamicLibrary {
+    fn drop(&mut self) {
+        unsafe {
+            close_library(self.handle);
+        }
+    }
+}
+
+#[cfg(windows)]
+fn cuda_library_names() -> &'static [&'static [u8]] {
+    &[b"nvcuda.dll\0"]
+}
+
+#[cfg(not(windows))]
+fn cuda_library_names() -> &'static [&'static [u8]] {
+    &[
+        b"libcuda.so.1\0",
+        b"libcuda.so\0",
+        b"/usr/lib/wsl/lib/libcuda.so\0",
+    ]
+}
+
+#[cfg(windows)]
+impl DynamicLibrary {
+    fn open(name: &[u8]) -> Result<Self, CudaError> {
+        unsafe {
+            let handle = LoadLibraryA(name.as_ptr().cast());
+            if handle.is_null() {
+                Err(CudaError::Load)
+            } else {
+                Ok(Self {
+                    handle: handle.cast(),
+                })
+            }
+        }
+    }
+
+    unsafe fn raw_symbol(&self, name: &[u8]) -> *mut c_void {
+        unsafe { GetProcAddress(self.handle.cast(), name.as_ptr().cast()).cast() }
+    }
+}
+
+#[cfg(not(windows))]
+impl DynamicLibrary {
+    fn open(name: &[u8]) -> Result<Self, CudaError> {
+        unsafe {
+            let handle = dlopen(name.as_ptr().cast(), 0x0001);
+            if handle.is_null() {
+                Err(CudaError::Load)
+            } else {
+                Ok(Self { handle })
+            }
+        }
+    }
+
+    unsafe fn raw_symbol(&self, name: &[u8]) -> *mut c_void {
+        unsafe { dlsym(self.handle, name.as_ptr().cast()) }
+    }
+}
+
+#[cfg(windows)]
+unsafe fn close_library(handle: *mut c_void) {
+    if !handle.is_null() {
+        let _ = unsafe { FreeLibrary(handle.cast()) };
+    }
+}
+
+#[cfg(not(windows))]
+unsafe fn close_library(handle: *mut c_void) {
+    if !handle.is_null() {
+        let _ = unsafe { dlclose(handle) };
+    }
+}
+
+#[cfg(windows)]
+#[link(name = "kernel32")]
+unsafe extern "system" {
+    fn LoadLibraryA(name: *const c_char) -> *mut c_void;
+    fn GetProcAddress(handle: *mut c_void, name: *const c_char) -> *mut c_void;
+    fn FreeLibrary(handle: *mut c_void) -> c_int;
+}
+
+#[cfg(not(windows))]
+#[link(name = "dl")]
+unsafe extern "C" {
+    fn dlopen(filename: *const c_char, flags: c_int) -> *mut c_void;
+    fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    fn dlclose(handle: *mut c_void) -> c_int;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::engine::kernels::apply_compiled_filter;
+    use crate::engine::seed::SearchState;
+    use crate::filters::FilterConfig;
+
+    #[test]
+    fn cuda_filter_compilation_matches_supported_surface() {
+        assert_cuda_supported(raw_cfg(
+            "",
+            "",
+            "tag_charm",
+            "",
+            "",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        ));
+        assert_cuda_supported(raw_cfg(
+            "v_telescope",
+            "",
+            "",
+            "",
+            "",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        ));
+        assert_cuda_supported(raw_cfg(
+            "",
+            "p_spectral_mega_1",
+            "",
+            "",
+            "",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        ));
+        assert_cuda_supported(raw_cfg(
+            "", "", "", "", "", 0.0, true, false, "b_red", false,
+        ));
+        assert_cuda_supported(raw_cfg(
+            "",
+            "",
+            "tag_charm",
+            "",
+            "",
+            0.0,
+            true,
+            false,
+            "b_red",
+            false,
+        ));
+        assert_cuda_supported(raw_cfg(
+            "v_telescope",
+            "p_spectral_mega_1",
+            "tag_charm",
+            "",
+            "",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        ));
+
+        let voucher_pack = raw_cfg(
+            "v_telescope",
+            "p_spectral_mega_1",
+            "",
+            "",
+            "",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        );
+        assert_eq!(
+            CompiledFilter::compile(&voucher_pack).shape,
+            KernelShape::VoucherSecondPack,
+        );
+        assert_cuda_supported(voucher_pack);
+        assert_cuda_supported(raw_cfg(
+            "v_telescope",
+            "p_spectral_mega_1",
+            "tag_charm",
+            "",
+            "",
+            1.0,
+            false,
+            false,
+            "b_red",
+            false,
+        ));
+
+        assert_cuda_unsupported(FilterConfig::default());
+        let no_match = raw_cfg(
+            "",
+            "",
+            "tag_buffoon",
+            "",
+            "",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        );
+        assert_eq!(
+            CompiledFilter::compile(&no_match).shape,
+            KernelShape::NoMatch
+        );
+        assert_cuda_unsupported(no_match);
+        assert_cuda_unsupported(raw_cfg(
+            "",
+            "",
+            "",
+            "",
+            "Blueprint",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        ));
+        assert_cuda_unsupported(raw_cfg(
+            "",
+            "p_arcana_mega_1",
+            "",
+            "",
+            "",
+            2.0,
+            false,
+            false,
+            "b_red",
+            false,
+        ));
+        assert_cuda_unsupported(raw_cfg(
+            "", "", "", "", "", 1.0, true, false, "b_red", false,
+        ));
+        assert_cuda_unsupported(raw_cfg(
+            "", "", "", "", "", 0.0, false, true, "b_red", false,
+        ));
+        assert_cuda_unsupported(raw_cfg(
+            "",
+            "",
+            "",
+            "",
+            "",
+            0.0,
+            false,
+            false,
+            "b_erratic",
+            true,
+        ));
+        assert_cuda_unsupported(raw_cfg(
+            "v_telescope",
+            "",
+            "",
+            "",
+            "",
+            0.0,
+            false,
+            false,
+            "b_magic",
+            false,
+        ));
+    }
+
+    #[test]
+    fn cuda_elides_always_true_first_buffoon_pack_constraint() {
+        let tag_and_buffoon = raw_cfg(
+            "",
+            "p_buffoon_normal_1",
+            "tag_charm",
+            "",
+            "",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        );
+        let params = compile_cuda_filter(&CompiledFilter::compile(&tag_and_buffoon))
+            .expect("tag plus Buffoon pack should still use CUDA for the tag check");
+        assert_eq!(params.flags & FLAG_TAGS, FLAG_TAGS);
+        assert_eq!(params.flags & FLAG_PACKS, 0);
+
+        assert_cuda_unsupported(raw_cfg(
+            "",
+            "p_buffoon_normal_1",
+            "",
+            "",
+            "",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        ));
+    }
+
+    #[test]
+    fn cuda_launch_grid_scales_with_count_and_caps_at_max_grid() {
+        assert_eq!(launch_grid_size(1), 1);
+        assert_eq!(launch_grid_size(i64::from(BLOCK_SIZE)), 1);
+        assert_eq!(launch_grid_size(i64::from(BLOCK_SIZE) + 1), 2);
+        assert_eq!(
+            launch_grid_size(i64::from(BLOCK_SIZE) * i64::from(GRID_SIZE) * 2),
+            GRID_SIZE,
+        );
+    }
+
+    #[test]
+    fn large_segments_start_with_a_bounded_probe_launch() {
+        assert_eq!(first_launch_size(PROBE_WINDOW_SEEDS - 1), LAUNCH_SEEDS);
+        assert_eq!(first_launch_size(PROBE_WINDOW_SEEDS), PROBE_LAUNCH_SEEDS);
+    }
+
+    #[test]
+    fn cuda_item_ids_match_the_kernel_contract() {
+        assert_eq!(mem::size_of::<Item>(), mem::size_of::<u16>());
+        assert_eq!(Item::Overstock as u16, 162);
+        assert_eq!(Item::Telescope as u16, 172);
+        assert_eq!(Item::Palette as u16, 193);
+        assert_eq!(Item::The_Soul as u16, 264);
+        assert_eq!(Item::Black_Hole as u16, 265);
+        assert_eq!(Item::Arcana_Pack as u16, 293);
+        assert_eq!(Item::Mega_Arcana_Pack as u16, 295);
+        assert_eq!(Item::Mega_Celestial_Pack as u16, 298);
+        assert_eq!(Item::Buffoon_Pack as u16, 302);
+        assert_eq!(Item::Spectral_Pack as u16, 305);
+        assert_eq!(Item::Mega_Spectral_Pack as u16, 307);
+        assert_eq!(Item::Uncommon_Tag as u16, 310);
+        assert_eq!(Item::Charm_Tag as u16, 320);
+        assert_eq!(Item::Economy_Tag as u16, 333);
+        assert_eq!(Item::Red_Deck as u16, 445);
+    }
+
+    #[test]
+    fn cuda_usage_marker_is_thread_local_and_resettable() {
+        reset_last_search_used();
+        assert!(!last_search_used());
+
+        mark_last_search_used();
+        assert!(last_search_used());
+        assert!(matches!(
+            std::thread::spawn(last_search_used).join(),
+            Ok(false)
+        ));
+        assert!(last_search_used());
+
+        reset_last_search_used();
+        assert!(!last_search_used());
+    }
+
+    #[test]
+    fn core_search_resets_cuda_usage_marker_before_early_returns() {
+        mark_last_search_used();
+        let _ = crate::brainstorm_search_core("", &FilterConfig::default(), 1, 1);
+        assert!(!last_search_used());
+    }
+
+    #[test]
+    #[ignore = "requires a compiled CUDA module, an NVIDIA driver, and a CUDA device"]
+    fn cuda_restores_the_callers_current_context() {
+        let driver = CudaDriver::load().expect("CUDA driver should load");
+        unsafe {
+            check((driver.cu_init)(0)).expect("CUDA should initialize");
+        }
+        let original = current_context(&driver);
+
+        let mut device = 0;
+        let mut caller = ptr::null_mut();
+        unsafe {
+            check((driver.cu_device_get)(&raw mut device, 0)).expect("device zero should exist");
+            check((driver.cu_ctx_create)(&raw mut caller, 0, device))
+                .expect("caller context should be created");
+        }
+        assert_eq!(current_context(&driver), caller);
+
+        let params = compile_cuda_filter(&CompiledFilter::compile(&raw_cfg(
+            "",
+            "",
+            "tag_charm",
+            "",
+            "",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        )))
+        .expect("tag filter should compile for CUDA");
+        let engine = CudaEngine::new().expect("CUDA engine should initialize");
+        assert_eq!(current_context(&driver), caller);
+
+        engine
+            .search(0, &params, 1_000)
+            .expect("CUDA search should complete");
+        assert_eq!(current_context(&driver), caller);
+
+        assert!(fail_while_engine_context_is_current(&engine).is_err());
+        assert_eq!(current_context(&driver), caller);
+
+        drop(engine);
+        assert_eq!(current_context(&driver), caller);
+
+        let mut popped = ptr::null_mut();
+        unsafe {
+            check((driver.cu_ctx_pop_current)(&raw mut popped)).expect("caller context should pop");
+        }
+        assert_eq!(popped, caller);
+        assert_eq!(current_context(&driver), original);
+        unsafe {
+            check((driver.cu_ctx_destroy)(caller)).expect("caller context should be destroyed");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires a compiled CUDA module, an NVIDIA driver, and a CUDA device"]
+    #[allow(clippy::panic)]
+    fn cuda_matches_cpu_results_and_scanned_counts() {
+        struct DisableCuda;
+        impl Drop for DisableCuda {
+            fn drop(&mut self) {
+                set_cuda_enabled(false);
+            }
+        }
+
+        let cases = [
+            (
+                "single tag",
+                "",
+                50_000,
+                true,
+                raw_cfg(
+                    "",
+                    "",
+                    "tag_charm",
+                    "",
+                    "",
+                    0.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "duplicate tag",
+                "",
+                50_000,
+                true,
+                raw_cfg(
+                    "", "", "tag_rare", "tag_rare", "", 0.0, false, false, "b_red", false,
+                ),
+            ),
+            (
+                "distinct tags",
+                "",
+                50_000,
+                true,
+                raw_cfg(
+                    "",
+                    "",
+                    "tag_charm",
+                    "tag_d_six",
+                    "",
+                    0.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "voucher",
+                "",
+                50_000,
+                true,
+                raw_cfg(
+                    "v_telescope",
+                    "",
+                    "",
+                    "",
+                    "",
+                    0.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "voucher second pack",
+                "",
+                50_000,
+                true,
+                raw_cfg(
+                    "v_telescope",
+                    "p_spectral_mega_1",
+                    "",
+                    "",
+                    "",
+                    0.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "Arcana pack",
+                "",
+                50_000,
+                true,
+                raw_cfg(
+                    "",
+                    "p_arcana_normal_1",
+                    "",
+                    "",
+                    "",
+                    0.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "Celestial pack",
+                "",
+                50_000,
+                true,
+                raw_cfg(
+                    "",
+                    "p_celestial_mega_1",
+                    "",
+                    "",
+                    "",
+                    0.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "Standard pack",
+                "",
+                50_000,
+                true,
+                raw_cfg(
+                    "",
+                    "p_standard_jumbo_1",
+                    "",
+                    "",
+                    "",
+                    0.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "Buffoon second pack",
+                "",
+                50_000,
+                true,
+                raw_cfg(
+                    "",
+                    "p_buffoon_mega_1",
+                    "",
+                    "",
+                    "",
+                    0.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "Spectral pack",
+                "",
+                50_000,
+                true,
+                raw_cfg(
+                    "",
+                    "p_spectral_jumbo_1",
+                    "",
+                    "",
+                    "",
+                    0.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "Observatory",
+                "",
+                50_000,
+                true,
+                raw_cfg("", "", "", "", "", 0.0, true, false, "b_red", false),
+            ),
+            (
+                "tag Observatory",
+                "",
+                50_000,
+                true,
+                raw_cfg(
+                    "",
+                    "",
+                    "tag_charm",
+                    "",
+                    "",
+                    0.0,
+                    true,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "Arcana Soul",
+                "",
+                100_000,
+                true,
+                raw_cfg(
+                    "",
+                    "p_arcana_mega_1",
+                    "",
+                    "",
+                    "",
+                    1.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "Soul without selected pack",
+                "",
+                100_000,
+                true,
+                raw_cfg("", "", "", "", "", 1.0, false, false, "b_red", false),
+            ),
+            (
+                "forced Buffoon elision",
+                "",
+                50_000,
+                true,
+                raw_cfg(
+                    "",
+                    "p_buffoon_normal_1",
+                    "tag_charm",
+                    "",
+                    "",
+                    0.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "composite miss",
+                "",
+                100_000,
+                false,
+                raw_cfg(
+                    "v_telescope",
+                    "p_spectral_mega_1",
+                    "tag_charm",
+                    "tag_d_six",
+                    "",
+                    0.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "spectral soul composite",
+                "OQMKIM11",
+                100_000,
+                false,
+                raw_cfg(
+                    "v_telescope",
+                    "p_spectral_mega_1",
+                    "tag_charm",
+                    "",
+                    "",
+                    1.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+            (
+                "seed-space wrap",
+                "ZZZZZZZZ",
+                100_000,
+                true,
+                raw_cfg(
+                    "",
+                    "p_spectral_mega_1",
+                    "tag_charm",
+                    "",
+                    "",
+                    0.0,
+                    false,
+                    false,
+                    "b_red",
+                    false,
+                ),
+            ),
+        ];
+
+        set_cuda_enabled(true);
+        let _disable = DisableCuda;
+        for (name, start, budget, should_match, cfg) in cases {
+            let start_id = Seed::from(start).id();
+            let compiled = CompiledFilter::compile(&cfg);
+            let expected = search_cpu(start_id, budget, &compiled);
+            assert_eq!(expected.is_some(), should_match, "fixture drift for {name}");
+            let CudaSearch::Complete(actual) = search_cuda(start_id, &compiled, budget) else {
+                panic!("CUDA unavailable for {name}");
+            };
+            assert_eq!(actual, expected, "result mismatch for {name}");
+            assert_eq!(
+                scanned_count(start_id, actual.as_deref(), budget),
+                scanned_count(start_id, expected.as_deref(), budget),
+                "scanned-count mismatch for {name}",
+            );
+        }
+
+        let prefix_hit = raw_cfg(
+            "",
+            "",
+            "tag_charm",
+            "",
+            "",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        );
+        let _ = crate::brainstorm_search_core("", &prefix_hit, 100_000, 1);
+        assert!(
+            !last_search_used(),
+            "a serial-prefix hit must report CPU use"
+        );
+
+        let composite_miss = raw_cfg(
+            "v_telescope",
+            "p_spectral_mega_1",
+            "tag_charm",
+            "tag_d_six",
+            "",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        );
+        let expected = search_cpu(0, 100_000, &CompiledFilter::compile(&composite_miss));
+        let actual = crate::brainstorm_search_core("", &composite_miss, 100_000, 1);
+        assert_eq!(actual, expected);
+        assert!(
+            last_search_used(),
+            "a completed kernel must report CUDA use"
+        );
+
+        reset_last_search_used();
+        let unsupported = CompiledFilter::compile(&raw_cfg(
+            "",
+            "",
+            "",
+            "",
+            "Blueprint",
+            0.0,
+            false,
+            false,
+            "b_red",
+            false,
+        ));
+        assert_eq!(search_cuda(0, &unsupported, 100_000), CudaSearch::Fallback);
+        assert!(
+            !last_search_used(),
+            "an unsupported filter must report CPU use"
+        );
+
+        let retained_context = cached_context().expect("CUDA engine should be cached");
+        set_cuda_enabled(false);
+        assert_eq!(cached_context(), Some(retained_context));
+        let actual = crate::brainstorm_search_core("", &composite_miss, 100_000, 1);
+        assert_eq!(actual, expected);
+        assert!(
+            !last_search_used(),
+            "a disabled CUDA arm must report CPU use"
+        );
+
+        set_cuda_enabled(true);
+        let actual = crate::brainstorm_search_core("", &composite_miss, 100_000, 1);
+        assert_eq!(actual, expected);
+        assert!(last_search_used());
+        assert_eq!(cached_context(), Some(retained_context));
+    }
+
+    #[test]
+    fn cuda_uses_specialized_kernel_only_for_selected_spectral_soul_filters() {
+        let spectral = compile_cuda_filter(&CompiledFilter::compile(&raw_cfg(
+            "v_telescope",
+            "p_spectral_mega_1",
+            "tag_charm",
+            "tag_charm",
+            "",
+            1.0,
+            false,
+            false,
+            "b_red",
+            false,
+        )))
+        .expect("selected Spectral Soul filter should compile for CUDA");
+        assert!(use_spectral_soul_kernel(&spectral));
+
+        let arcana = compile_cuda_filter(&CompiledFilter::compile(&raw_cfg(
+            "",
+            "p_arcana_mega_1",
+            "tag_charm",
+            "",
+            "",
+            1.0,
+            false,
+            false,
+            "b_red",
+            false,
+        )))
+        .expect("selected Arcana Soul filter should compile for CUDA");
+        assert!(!use_spectral_soul_kernel(&arcana));
+
+        let observatory = compile_cuda_filter(&CompiledFilter::compile(&raw_cfg(
+            "",
+            "",
+            "tag_charm",
+            "",
+            "",
+            0.0,
+            true,
+            false,
+            "b_red",
+            false,
+        )))
+        .expect("tag Observatory filter should compile for CUDA");
+        assert!(!use_spectral_soul_kernel(&observatory));
+    }
+
+    fn assert_cuda_supported(cfg: FilterConfig) {
+        assert!(
+            compile_cuda_filter(&CompiledFilter::compile(&cfg)).is_some(),
+            "{cfg:?} should compile for CUDA",
+        );
+    }
+
+    fn search_cpu(start_seed: i64, count: i64, cfg: &CompiledFilter) -> Option<String> {
+        let mut state = SearchState::from_id(start_seed);
+        for _ in 0..count {
+            if apply_compiled_filter(&mut state, cfg) {
+                return Some(state.seed.to_string());
+            }
+            state.next();
+        }
+        None
+    }
+
+    fn current_context(driver: &CudaDriver) -> CUcontext {
+        let mut context = ptr::null_mut();
+        unsafe {
+            check((driver.cu_ctx_get_current)(&raw mut context))
+                .expect("current CUDA context should be readable");
+        }
+        context
+    }
+
+    fn fail_while_engine_context_is_current(engine: &CudaEngine) -> Result<(), CudaError> {
+        let _current = CurrentContext::push(&engine.driver, engine.context)?;
+        Err(CudaError::Driver)
+    }
+
+    fn cached_context() -> Option<usize> {
+        let state = CUDA_STATE.get()?;
+        let guard = state.lock().ok()?;
+        guard.engine.as_ref().map(|engine| engine.context as usize)
+    }
+
+    fn scanned_count(start_seed: i64, result: Option<&str>, budget: i64) -> i64 {
+        result.map_or(budget, |seed| {
+            (Seed::from(seed).id() - start_seed).rem_euclid(SEED_SPACE) + 1
+        })
+    }
+
+    fn assert_cuda_unsupported(cfg: FilterConfig) {
+        assert!(
+            compile_cuda_filter(&CompiledFilter::compile(&cfg)).is_none(),
+            "{cfg:?} should use the Rust CPU path",
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn raw_cfg(
+        voucher: &str,
+        pack: &str,
+        tag1: &str,
+        tag2: &str,
+        joker: &str,
+        souls: f64,
+        observatory: bool,
+        perkeo: bool,
+        deck: &str,
+        erratic: bool,
+    ) -> FilterConfig {
+        FilterConfig::from_raw(
+            voucher,
+            pack,
+            tag1,
+            tag2,
+            joker,
+            "any",
+            souls,
+            observatory,
+            perkeo,
+            deck,
+            erratic,
+            false,
+            0,
+            0.0,
+        )
+    }
+}

--- a/Immolate/src/engine/mod.rs
+++ b/Immolate/src/engine/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod config;
+pub(crate) mod cuda;
 pub(crate) mod kernels;
 pub(crate) mod rng;
 pub(crate) mod search;

--- a/Immolate/src/engine/search.rs
+++ b/Immolate/src/engine/search.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicI64, Ordering};
 use std::thread;
 
 use crate::engine::config::{CompiledFilter, KernelShape};
+use crate::engine::cuda::{CudaSearch, mark_last_search_used, reset_last_search_used, search_cuda};
 use crate::engine::kernels::apply_compiled_filter;
 use crate::engine::seed::SearchState;
 use crate::filters::FilterConfig;
@@ -14,6 +15,7 @@ pub fn brainstorm_search_core(
     num_seeds: i64,
     threads: i32,
 ) -> Option<String> {
+    reset_last_search_used();
     let budget = resolve_seed_budget(num_seeds);
     let compiled = CompiledFilter::compile(cfg);
     search_filters(seed_start, compiled, budget, threads)
@@ -49,9 +51,6 @@ fn search_filters(
     if cfg.shape == KernelShape::NoFilter {
         return Some(Seed::from_id(start_seed).to_string());
     }
-    if requested_threads == 1 {
-        return search_block(start_seed, num_seeds, &cfg);
-    }
     let prefix_count = cfg.serial_prefix_size().min(num_seeds);
     if let Some(seed) = search_block(start_seed, prefix_count, &cfg) {
         return Some(seed);
@@ -61,6 +60,10 @@ fn search_filters(
     }
     let remaining_start = (start_seed + prefix_count).rem_euclid(SEED_SPACE);
     let remaining = num_seeds - prefix_count;
+    if let CudaSearch::Complete(result) = search_cuda(remaining_start, &cfg, remaining) {
+        mark_last_search_used();
+        return result;
+    }
     let thread_count = resolve_threads_for_engine(
         remaining,
         requested_threads,

--- a/Immolate/src/ffi.rs
+++ b/Immolate/src/ffi.rs
@@ -6,6 +6,7 @@ use std::os::raw::{c_char, c_double, c_int, c_longlong};
 use std::ptr;
 
 use crate::brainstorm_search_core;
+use crate::engine::cuda;
 use crate::filters::FilterConfig;
 
 /// Searches for the earliest matching seed.
@@ -35,6 +36,7 @@ pub(crate) unsafe extern "C" fn brainstorm_search(
     num_seeds: c_longlong,
     threads: c_int,
 ) -> *mut c_char {
+    cuda::reset_last_search_used();
     let search = || {
         // SAFETY: the caller upholds every input pointer's validity for this call.
         let (
@@ -135,6 +137,16 @@ fn brainstorm_search_impl(
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn immolate_set_log_path(_path: *const c_char) {}
 
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn immolate_set_cuda_enabled(enabled: bool) {
+    cuda::set_cuda_enabled(enabled);
+}
+
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn immolate_last_search_used_cuda() -> bool {
+    cuda::last_search_used()
+}
+
 /// Releases a result returned by [`brainstorm_search`].
 ///
 /// # Safety
@@ -188,5 +200,16 @@ mod tests {
         // SAFETY: the static C literal remains valid and immutable.
         let value = unsafe { c_string_lossy(c"K\xff".as_ptr()) };
         assert!(matches!(value, Cow::Owned(value) if value == "K\u{fffd}"));
+    }
+
+    #[test]
+    fn cuda_status_export_reports_the_current_threads_marker() {
+        cuda::reset_last_search_used();
+        assert!(!immolate_last_search_used_cuda());
+
+        cuda::mark_last_search_used();
+        assert!(immolate_last_search_used_cuda());
+
+        cuda::reset_last_search_used();
     }
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Current release: **v3.6**.
 
+The `v4-cuda` branch is an unreleased experiment. It keeps the Rust CPU engine
+as the correctness fallback and adds an explicit, user-controlled CUDA path for
+supported searches.
+
 **Just want to install it?** Open this repository's **Releases** page, select
 the release marked **Latest**, download the Brainstorm Supercharged zip, and
 follow the installation guide written in that release.
@@ -75,6 +79,9 @@ This project is licensed under CC BY-NC-SA 4.0.
 - Rust benchmark harness compares current speed against the Original Brainstorm
   DLL where the older ABI supports the same fixture, and reports comparable
   result mismatches.
+- Optional CUDA acceleration for supported filters, controlled only by the
+  `AR: Use CUDA` setting; unavailable or unsupported GPU searches fall back to
+  the Rust CPU engine.
 - Production release automation publishes immutable versioned releases and
   marks the newest one as **Latest**.
 
@@ -92,8 +99,16 @@ This project is licensed under CC BY-NC-SA 4.0.
 
 - MinGW-w64 and Wine are required for Windows DLL builds, DLL validation, and
   benchmarks.
-- WSL interoperability (`wslpath` and `cmd.exe`) is required for the
-  native-Windows current/current regression gate.
+- WSL interoperability (`wslpath`, `cmd.exe`, and `powershell.exe`) is required
+  for the native-Windows regression and CUDA benchmark gates.
+- CUDA Toolkit with `nvcc` is required for a GPU-enabled experimental build.
+  Set `BRAINSTORM_SKIP_CUDA_BUILD=1` only when intentionally validating its CPU
+  fallback. The experiment defaults to `sm_89` and `gcc-12`; override
+  `CUDAHOSTCXX` or `NVCC` for another toolchain. Each build embeds one
+  precompiled GPU architecture: set `BRAINSTORM_CUDA_ARCH` to your GPU's `sm_*`
+  architecture before building. A driver that cannot load it falls back to
+  Rust CPU. CUDA initialization and runtime failures stay on CPU for the rest
+  of that game process; restart Balatro to retry the GPU.
 - Write access to `%AppData%\Roaming\Balatro\Mods`.
 
 ## Build & Deploy (from source)
@@ -143,6 +158,13 @@ For native Linux-side Rust profiling without the Windows DLL ABI, use
 `brainstorm_bench` as described in `Immolate/BENCH.md`.
 
 See `Immolate/BENCH.md` for benchmark workflows.
+
+The closest benchmark to the in-game CUDA path runs the Windows DLL and driver
+natively from WSL:
+
+```bash
+mise run bench-cuda-long-windows
+```
 
 ## Versioning & Release
 
@@ -207,13 +229,15 @@ not part of the release payload.
 - Open settings: Ctrl+T. Toggle auto-reroll: Ctrl+A. Manual reroll: Ctrl+R.
 - Save/load state: Z/X + 1-5.
 - Configure filters: dual tags, voucher, pack (two shop slots), Joker
-  (searchable list + location), souls, observatory, Perkeo.
+  (searchable list + location), one Soul, Observatory, Perkeo.
 - Impossible first-shop Joker targets are hidden from the Joker selector, and
   impossible native filter combinations return no match immediately.
 - Configure Erratic Deck filters when searching for opening hands by face-card
   count, no faces, or suit concentration.
 - Use "Enable Brainstorm Supercharged" to disable runtime actions without
   losing settings.
+- `AR: Use CUDA` enables the experimental GPU path by default on this branch;
+  turn it off to force Rust CPU.
 - Use "Reset All" in the Brainstorm Supercharged tab to restore filter and
   Erratic deck settings to defaults.
 
@@ -222,3 +246,5 @@ not part of the release payload.
 - Missing DLL or wrong build: rerun `mise run build` and
   `mise run deploy`. If auto-detection fails, set `TARGET` to the full
   `.../Balatro/Mods/Brainstorm` path.
+- Experimental branch Lua must use the DLL built from the same branch; the
+  v3.6 release DLL does not provide the CUDA control ABI.

--- a/UI.lua
+++ b/UI.lua
@@ -479,6 +479,13 @@ function Brainstorm.build_settings_tab()
                 ),
               }),
               create_toggle({
+                label = "AR: Use CUDA",
+                scale = 0.8,
+                ref_table = config.ar_prefs,
+                ref_value = "use_cuda",
+                callback = write_config,
+              }),
+              create_toggle({
                 label = "AR: INST OBSERVATORY",
                 scale = 0.8,
                 ref_table = Brainstorm.config.ar_filters,

--- a/mise.toml
+++ b/mise.toml
@@ -69,15 +69,27 @@ check_cmd luacheck
 check_cmd x86_64-w64-mingw32-gcc
 check_cmd x86_64-w64-mingw32-objdump
 check_cmd wine
+if [ "${BRAINSTORM_SKIP_CUDA_BUILD:-0}" = "1" ]; then
+  echo "skipped: nvcc (BRAINSTORM_SKIP_CUDA_BUILD=1)"
+else
+  check_cmd "${NVCC:-nvcc}"
+  check_cmd "${CUDAHOSTCXX:-gcc-12}"
+fi
 check_cmd file
 check_cmd sha256sum
 check_cmd zip
 check_cmd rsync
 
-if command -v wslpath >/dev/null && command -v cmd.exe >/dev/null; then
+powershell="${POWERSHELL_EXE:-powershell.exe}"
+if ! command -v "$powershell" >/dev/null; then
+  powershell="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+fi
+if command -v wslpath >/dev/null \
+  && command -v cmd.exe >/dev/null \
+  && command -v "$powershell" >/dev/null; then
   echo "ok: native Windows benchmark interop"
 else
-  echo "optional: wslpath/cmd.exe unavailable; use BENCH_EXECUTOR=wine for diagnostics"
+  echo "optional: wslpath/cmd.exe/powershell.exe unavailable; use BENCH_EXECUTOR=wine for diagnostics"
 fi
 
 rust_target="${RUST_TARGET:-x86_64-pc-windows-gnu}"
@@ -255,7 +267,7 @@ exports="$(
     sed -n '/^\[Ordinal\/Name Pointer\] Table/,/^$/p' |
     awk '/\[[[:space:]]*[0-9]+\]/{print $NF}'
 )"
-expected="$(printf '%s\n' brainstorm_search free_result immolate_set_log_path | sort)"
+expected="$(printf '%s\n' brainstorm_search free_result immolate_last_search_used_cuda immolate_set_cuda_enabled immolate_set_log_path | sort)"
 actual="$(printf '%s\n' "$exports" | sort)"
 if [ "$actual" != "$expected" ]; then
   echo "unexpected Rust DLL exports:"
@@ -291,6 +303,7 @@ bench_budget="${BENCH_BUDGET:-1000000}"
 bench_threads="${BENCH_THREADS:-0}"
 bench_repeat="${BENCH_REPEAT:-5}"
 bench_warmup="${BENCH_WARMUP:-1}"
+bench_cuda="${BENCH_CUDA:-default}"
 bench_format="${BENCH_FORMAT:-pretty}"
 bench_color="${BENCH_COLOR:-auto}"
 wine "$harness" bench \
@@ -300,12 +313,13 @@ wine "$harness" bench \
   --threads "$bench_threads" \
   --repeat "$bench_repeat" \
   --warmup "$bench_warmup" \
+  --cuda "$bench_cuda" \
   --format "$bench_format" \
   --color "$bench_color"
 '''
 
 [tasks.bench-compare]
-description = "Benchmark Rust against the Original Brainstorm DLL"
+description = "Benchmark Rust CPU/CUDA against the Original Brainstorm DLL"
 shell = "bash -c"
 run = '''
 set -euo pipefail
@@ -321,6 +335,7 @@ bench_budget="${BENCH_BUDGET:-1000000}"
 bench_threads="${BENCH_THREADS:-0}"
 bench_repeat="${BENCH_REPEAT:-5}"
 bench_warmup="${BENCH_WARMUP:-1}"
+bench_cuda="${BENCH_CUDA:-both}"
 bench_min_ratio="${BENCH_MIN_RATIO:-1.0}"
 bench_fail_on_mismatch="${BENCH_FAIL_ON_MISMATCH:-0}"
 bench_format="${BENCH_FORMAT:-pretty}"
@@ -339,10 +354,85 @@ wine "$harness" bench-compare \
   --threads "$bench_threads" \
   --repeat "$bench_repeat" \
   --warmup "$bench_warmup" \
+  --cuda "$bench_cuda" \
   --min-ratio "$bench_min_ratio" \
   --fail-on-mismatch "$bench_fail_on_mismatch" \
   --format "$bench_format" \
   --color "$bench_color"
+'''
+
+[tasks.bench-compare-windows]
+description = "Benchmark Rust CPU/CUDA against the Original DLL as a native Windows process"
+shell = "bash -c"
+run = '''
+set -euo pipefail
+mise run build-rust
+mise run build-harness
+
+powershell="${POWERSHELL_EXE:-powershell.exe}"
+if ! command -v "$powershell" >/dev/null; then
+  powershell="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+fi
+command -v "$powershell" >/dev/null || {
+  echo "powershell.exe not found. Run from WSL with Windows interop enabled."
+  exit 1
+}
+
+rust_artifact="$TARGET_DIR/rust/$DLL"
+original_dll="${BENCH_ORIGINAL_DLL:-${ORIGINAL_DLL:-$IMMO_DIR/Immolate-OceanRamenandMathIsFun0.dll}}"
+rust_target="${RUST_TARGET:-x86_64-pc-windows-gnu}"
+harness="$IMMO_DIR/target/$rust_target/release/immolate_dll_harness.exe"
+
+[ -f "$original_dll" ] || { echo "original DLL not found: $original_dll"; exit 1; }
+
+export BS_HARNESS_WIN="$(wslpath -w "$(readlink -f "$harness")")"
+export BS_RUST_DLL_WIN="$(wslpath -w "$(readlink -f "$rust_artifact")")"
+export BS_ORIGINAL_DLL_WIN="$(wslpath -w "$(readlink -f "$original_dll")")"
+export BS_CASE="${BENCH_CASE:-all}"
+export BS_BUDGET="${BENCH_BUDGET:-1000000}"
+export BS_THREADS="${BENCH_THREADS:-0}"
+export BS_REPEAT="${BENCH_REPEAT:-5}"
+export BS_WARMUP="${BENCH_WARMUP:-1}"
+export BS_CUDA="${BENCH_CUDA:-both}"
+export BS_MIN_RATIO="${BENCH_MIN_RATIO:-1.0}"
+export BS_FAIL_ON_MISMATCH="${BENCH_FAIL_ON_MISMATCH:-0}"
+export BS_FORMAT="${BENCH_FORMAT:-pretty}"
+export BS_COLOR="${BENCH_COLOR:-auto}"
+export WSLENV="${WSLENV:+$WSLENV:}BS_HARNESS_WIN/w:BS_RUST_DLL_WIN/w:BS_ORIGINAL_DLL_WIN/w:BS_CASE/w:BS_BUDGET/w:BS_THREADS/w:BS_REPEAT/w:BS_WARMUP/w:BS_CUDA/w:BS_MIN_RATIO/w:BS_FAIL_ON_MISMATCH/w:BS_FORMAT/w:BS_COLOR/w"
+
+"$powershell" -NoProfile -ExecutionPolicy Bypass -Command '
+& $env:BS_HARNESS_WIN bench-compare `
+  --rust $env:BS_RUST_DLL_WIN `
+  --original $env:BS_ORIGINAL_DLL_WIN `
+  --case $env:BS_CASE `
+  --budget $env:BS_BUDGET `
+  --threads $env:BS_THREADS `
+  --repeat $env:BS_REPEAT `
+  --warmup $env:BS_WARMUP `
+  --cuda $env:BS_CUDA `
+  --min-ratio $env:BS_MIN_RATIO `
+  --fail-on-mismatch $env:BS_FAIL_ON_MISMATCH `
+  --format $env:BS_FORMAT `
+  --color $env:BS_COLOR
+'
+'''
+
+[tasks.bench-cuda-long-windows]
+description = "Native Windows long CUDA benchmark from WSL"
+shell = "bash -c"
+run = '''
+set -euo pipefail
+BENCH_CASE="${BENCH_CASE:-cuda-long}" \
+BENCH_BUDGET="${BENCH_BUDGET:-25000000}" \
+BENCH_REPEAT="${BENCH_REPEAT:-3}" \
+BENCH_WARMUP="${BENCH_WARMUP:-1}" \
+BENCH_THREADS="${BENCH_THREADS:-0}" \
+BENCH_CUDA="${BENCH_CUDA:-both}" \
+BENCH_FORMAT="${BENCH_FORMAT:-pretty}" \
+BENCH_COLOR="${BENCH_COLOR:-never}" \
+BENCH_MIN_RATIO="${BENCH_MIN_RATIO:-0.0}" \
+BENCH_FAIL_ON_MISMATCH="${BENCH_FAIL_ON_MISMATCH:-0}" \
+mise run bench-compare-windows
 '''
 
 [tasks.bench-current-compare]
@@ -417,6 +507,7 @@ BENCH_BUDGET=100000 \
 BENCH_REPEAT=5 \
 BENCH_WARMUP=2 \
 BENCH_THREADS=0 \
+BENCH_CUDA=both \
 BENCH_FORMAT=tsv \
 BENCH_COLOR=never \
 BENCH_MIN_RATIO=1.0 \
@@ -433,6 +524,7 @@ BENCH_BUDGET=100000 \
 BENCH_REPEAT=5 \
 BENCH_WARMUP=2 \
 BENCH_THREADS=0 \
+BENCH_CUDA=both \
 BENCH_FORMAT=tsv \
 BENCH_COLOR=never \
 BENCH_MIN_RATIO=1.0 \
@@ -449,6 +541,7 @@ BENCH_BUDGET=1000000 \
 BENCH_REPEAT=7 \
 BENCH_WARMUP=2 \
 BENCH_THREADS=0 \
+BENCH_CUDA=both \
 BENCH_FORMAT=pretty \
 BENCH_COLOR=always \
 BENCH_MIN_RATIO=1.0 \
@@ -483,6 +576,7 @@ smoke_bench() {
     --threads "${BENCH_THREADS:-0}" \
     --repeat 1 \
     --warmup "${BENCH_WARMUP:-1}" \
+    --cuda both \
     --format "${BENCH_FORMAT:-pretty}" \
     --color "${BENCH_COLOR:-auto}"
 }

--- a/tests/lua_lifecycle_smoke.lua
+++ b/tests/lua_lifecycle_smoke.lua
@@ -2,6 +2,12 @@
 
 local repo = assert(arg[1], "repository path is required")
 local native_calls = {}
+local cuda_settings = {}
+local cuda_at_search = {}
+local active_cuda_setting
+local fail_cuda_setting = false
+local omit_cuda_export = false
+local ffi_declarations
 local native_loads = 0
 local native_handle_ref = setmetatable({}, { __mode = "v" })
 
@@ -11,19 +17,33 @@ end
 package.preload.ffi = function()
   return {
     NULL = {},
-    cdef = function() end,
+    cdef = function(declarations)
+      ffi_declarations = declarations
+    end,
     load = function(path)
       assert(path == repo .. "/Brainstorm/Immolate.dll")
       native_loads = native_loads + 1
       local handle = {
         brainstorm_search = function(...)
+          assert(active_cuda_setting ~= nil, "CUDA setting must precede search")
+          cuda_at_search[#cuda_at_search + 1] = active_cuda_setting
           native_calls[#native_calls + 1] = { ... }
           return nil
         end,
         free_result = function()
           error("nil native results must not be freed")
         end,
+        immolate_set_cuda_enabled = function(enabled)
+          if fail_cuda_setting then
+            error("synthetic CUDA setting failure")
+          end
+          cuda_settings[#cuda_settings + 1] = enabled
+          active_cuda_setting = enabled
+        end,
       }
+      if omit_cuda_export then
+        handle.immolate_set_cuda_enabled = nil
+      end
       native_handle_ref[1] = handle
       return handle
     end,
@@ -149,6 +169,7 @@ assert(written_config == "packed config")
 local config_identity = Brainstorm.config
 Brainstorm.reset_config()
 assert(Brainstorm.config == config_identity)
+assert(Brainstorm.config.ar_prefs.use_cuda)
 
 package.preload.brainstorm_supercharged_ui = function()
   error("synthetic UI module failure")
@@ -173,7 +194,11 @@ STR_UNPACK = function(packed)
   return {
     enable = false,
     ar_filters = { pack = "p_arcana_normal_1" },
-    ar_prefs = { spf_int = 250000, suit_ratio_percent = "75%" },
+    ar_prefs = {
+      spf_int = 250000,
+      use_cuda = false,
+      suit_ratio_percent = "75%",
+    },
   }
 end
 Brainstorm.load_config()
@@ -181,6 +206,7 @@ assert(Brainstorm.config == config_identity)
 assert(not Brainstorm.config.enable)
 assert(Brainstorm.config.ar_filters.pack == "p_arcana_normal_1")
 assert(Brainstorm.config.ar_prefs.spf_int == 250000)
+assert(not Brainstorm.config.ar_prefs.use_cuda)
 assert(Brainstorm.config.ar_prefs.suit_ratio_percent == "75%")
 assert(written_config == nil)
 
@@ -203,6 +229,7 @@ local normalized = Brainstorm.normalize_config({
   ar_prefs = {
     spf_int = 250000,
     spf_id = 2,
+    use_cuda = false,
     suit_ratio_percent = "75%",
     suit_ratio_id = 6,
     suit_ratio_decimal = 0.1,
@@ -211,6 +238,7 @@ local normalized = Brainstorm.normalize_config({
 assert(normalized.ar_filters.pack == "p_arcana_normal_1")
 assert(normalized.ar_filters.voucher_name == "v_telescope")
 assert(normalized.ar_prefs.spf_int == 250000)
+assert(not normalized.ar_prefs.use_cuda)
 assert(normalized.ar_prefs.suit_ratio_percent == "75%")
 for _, key in ipairs({
   "pack_id",
@@ -228,6 +256,13 @@ end
 assert(
   Brainstorm.normalize_config({ ar_filters = { pack = { "legacy" } } }).ar_filters.pack
     == ""
+)
+assert(
+  Brainstorm.normalize_config({ ar_prefs = { use_cuda = "legacy" } }).ar_prefs.use_cuda
+)
+assert(
+  Brainstorm.normalize_config({ ar_filters = { soul_skip = 5 } }).ar_filters.soul_skip
+    == 1
 )
 
 local function assert_native_call(actual, expected)
@@ -259,12 +294,23 @@ filters.inst_perkeo = false
 prefs.face_count = 12
 prefs.suit_ratio_percent = "75%"
 prefs.spf_int = 100000
+prefs.use_cuda = true
 G.GAME = {
   stake = 2,
   seeded = true,
   selected_back_key = { key = "b_red" },
   starting_params = {},
 }
+omit_cuda_export = true
+local missing_result, missing_error = Brainstorm.auto_reroll()
+assert(
+  missing_result == false
+    and missing_error
+      == "Auto-reroll stopped (Immolate.dll missing or incompatible)"
+)
+assert(#native_calls == 0 and #cuda_settings == 0)
+omit_cuda_export = false
+seed_number = 0
 assert(Brainstorm.auto_reroll() == nil)
 
 filters.voucher_name = "v_clearance_sale"
@@ -285,7 +331,16 @@ G.GAME.starting_params.no_faces = true
 assert(Brainstorm.auto_reroll() == nil)
 
 assert(Brainstorm.config == config_identity)
-assert(native_loads == 1 and #native_calls == 2)
+assert(native_loads == 2 and #native_calls == 2)
+assert(
+  ffi_declarations:find(
+    "void immolate_set_cuda_enabled(bool enabled);",
+    1,
+    true
+  )
+)
+assert(#cuda_settings == 1 and cuda_settings[1] == true)
+assert(cuda_at_search[1] == true and cuda_at_search[2] == true)
 assert_native_call(native_calls[1], {
   "SEED0001",
   "v_telescope",
@@ -324,6 +379,32 @@ assert_native_call(native_calls[2], {
   250000,
   0,
 })
+
+prefs.use_cuda = false
+assert(Brainstorm.auto_reroll() == nil)
+assert(#native_calls == 3)
+assert(#cuda_settings == 2 and cuda_settings[2] == false)
+assert(cuda_at_search[3] == false)
+assert(native_calls[3][1] == "SEED0003")
+for index = 2, 17 do
+  assert(native_calls[3][index] == native_calls[2][index])
+end
+
+fail_cuda_setting = true
+prefs.use_cuda = true
+local cuda_result, cuda_error = Brainstorm.auto_reroll()
+assert(cuda_result == false and cuda_error:find("CUDA setting failed", 1, true))
+assert(#native_calls == 3 and #cuda_settings == 2)
+
+fail_cuda_setting = false
+assert(Brainstorm.auto_reroll() == nil)
+assert(#native_calls == 4)
+assert(#cuda_settings == 3 and cuda_settings[3] == true)
+assert(cuda_at_search[4] == true)
+assert(native_calls[4][1] == "SEED0005")
+for index = 2, 17 do
+  assert(native_calls[4][index] == native_calls[3][index])
+end
 collectgarbage()
 collectgarbage()
 assert(native_handle_ref[1] ~= nil)

--- a/tests/lua_ui_smoke.lua
+++ b/tests/lua_ui_smoke.lua
@@ -1,6 +1,7 @@
 -- luacheck: globals Brainstorm G UIBox_button create_option_cycle create_tabs create_text_input create_toggle darken
 
 local repo = assert(arg[1], "repository path is required")
+local config_writes = 0
 
 Brainstorm = {
   DEFAULT_SPF_KEY = "100000",
@@ -29,11 +30,14 @@ Brainstorm = {
     },
     ar_prefs = {
       spf_int = 100000,
+      use_cuda = true,
       face_count = 0,
       suit_ratio_percent = "Disabled",
     },
   },
-  write_config = function() end,
+  write_config = function()
+    config_writes = config_writes + 1
+  end,
   reset_config = function() end,
 }
 
@@ -63,6 +67,7 @@ G = {
 }
 
 local cycles = {}
+local toggles = {}
 create_option_cycle = function(args)
   cycles[args.label] = args
   return args
@@ -71,6 +76,7 @@ create_text_input = function(args)
   return args
 end
 create_toggle = function(args)
+  toggles[args.label] = args
   return args
 end
 UIBox_button = function(args)
@@ -106,6 +112,13 @@ local face_options = cycles["ED: Min. # of Face Cards"].options
 local soul_options = cycles["AR: N. SOULS"].options
 assert(#face_options == 36 and face_options[1] == 0 and face_options[36] == 35)
 assert(#soul_options == 2 and soul_options[1] == 0 and soul_options[2] == 1)
+
+local cuda_toggle = toggles["AR: Use CUDA"]
+assert(cuda_toggle.ref_table == Brainstorm.config.ar_prefs)
+assert(cuda_toggle.ref_value == "use_cuda")
+cuda_toggle.ref_table[cuda_toggle.ref_value] = false
+cuda_toggle.callback()
+assert(not Brainstorm.config.ar_prefs.use_cuda and config_writes == 1)
 
 G.P_CENTER_POOLS.Joker[#G.P_CENTER_POOLS.Joker + 1] =
   { set = "Joker", name = "Beta", rarity = 2 }


### PR DESCRIPTION
Add explicit Lua-controlled CUDA acceleration for source-faithful Red Deck tag, voucher, pack, Observatory, and Soul searches while retaining Rust CPU fallback and earliest-seed semantics.

Embed a target-specific precompiled CUDA module, isolate dynamic driver and context lifecycle, attest actual backend use, and add CPU/GPU parity plus native Windows benchmark coverage. Polish Lua config/UI, benchmark reporting, docs, and tooling for the experimental v4-cuda workflow.